### PR TITLE
Map provider to forked provider name when different

### DIFF
--- a/main.go
+++ b/main.go
@@ -37,9 +37,6 @@ func cmd() *cobra.Command {
 		Short: "upgrade-provider automatics the process of upgrading a TF-bridged provider",
 		Args:  cobra.ExactArgs(1),
 		Run: func(_ *cobra.Command, args []string) {
-			if err := os.Setenv("GOWORK", "off"); err != nil {
-				return fmt.Errorf("disabling go workspaces: %w", err)
-			}
 			gopath, ok := os.LookupEnv("GOPATH")
 			if !ok {
 				gopath = build.Default.GOPATH
@@ -129,7 +126,7 @@ func UpgradeProvider(ctx Context, name string) error {
 				return ensurePulumiRemote(ctx, remoteName)
 			}).In(&upstreamPath),
 			step.Cmd(exec.Command("git", "fetch", "pulumi")).In(&upstreamPath),
-			step.Cmd(exec.Command("git", "fetch", "--all", "--tags")).In(&upstreamPath),
+			step.Cmd(exec.Command("git", "fetch", "origin", "--tags")).In(&upstreamPath),
 			step.F("Discover Previous Upstream Version", func() (string, error) {
 				return runGitCommand(ctx, func(b []byte) (string, error) {
 					lines := strings.Split(string(b), "\n")
@@ -278,7 +275,7 @@ func UpgradeProvider(ctx Context, name string) error {
 			step.Cmd(exec.CommandContext(ctx, "git", "commit", "-m", "make tfgen")).In(&path),
 			step.Cmd(exec.CommandContext(ctx, "make", "build_sdks")).In(&path),
 			step.Cmd(exec.CommandContext(ctx, "git", "add", "--all")).In(&path),
-			step.Cmd(exec.CommandContext(ctx, "git", "commit", "-m", "make build_sdks")).In(&path),
+			step.Cmd(exec.CommandContext(ctx, "git", "commit", "-m", "make build_sdks", "--allow-empty")).In(&path),
 			step.Combined("Open PR",
 				step.Cmd(exec.CommandContext(ctx, "git", "push", "--set-upstream", "origin", branchName)).In(&path),
 				step.Cmd(exec.CommandContext(ctx, "gh", "pr", "create",

--- a/main.go
+++ b/main.go
@@ -37,7 +37,9 @@ func cmd() *cobra.Command {
 		Short: "upgrade-provider automatics the process of upgrading a TF-bridged provider",
 		Args:  cobra.ExactArgs(1),
 		Run: func(_ *cobra.Command, args []string) {
-			os.Setenv("GOWORK", "off")
+			if err := os.Setenv("GOWORK", "off"); err != nil {
+				return fmt.Errorf("disabling go workspaces: %w", err)
+			}
 			gopath, ok := os.LookupEnv("GOPATH")
 			if !ok {
 				gopath = build.Default.GOPATH

--- a/provider-owners.go
+++ b/provider-owners.go
@@ -5,5 +5,10 @@ var ProviderOrgs = map[string]string{
 }
 
 var ProviderName = map[string]string{
-	"f5bigip": "bigip",
+	"f5bigip":        "bigip",
+	"confluentcloud": "confluent",
+}
+
+var ForkedName = map[string]string{
+	"confluentcloud": "confluent",
 }

--- a/provider-owners.go
+++ b/provider-owners.go
@@ -8,7 +8,3 @@ var ProviderName = map[string]string{
 	"f5bigip":        "bigip",
 	"confluentcloud": "confluent",
 }
-
-var ForkedName = map[string]string{
-	"confluentcloud": "confluent",
-}

--- a/step/step.go
+++ b/step/step.go
@@ -53,6 +53,9 @@ func (ds step) run(prefix string) bool {
 	}
 	spinner.Stop()
 	fmt.Printf(" %s: %s\n", ds.description, result)
+	if strings.Contains(ds.description, "git commit -m") {
+		return true
+	}
 	return err == nil
 }
 

--- a/step/step.go
+++ b/step/step.go
@@ -53,9 +53,6 @@ func (ds step) run(prefix string) bool {
 	}
 	spinner.Stop()
 	fmt.Printf(" %s: %s\n", ds.description, result)
-	if strings.Contains(ds.description, "git commit -m") {
-		return true
-	}
 	return err == nil
 }
 


### PR DESCRIPTION
This PR implements a few minor changes:
- Usually the pulumi provider name is the same as the upstream, but we need to map it correctly when it differs (i.e. `pulumi-confluentcloud` to `confluent`)
- For forked providers, fetches all tags of upstream provider so the latest can be merged into a new branch of the forked provider