### PR TITLE
Set GOWORK=off

### DIFF
--- a/main.go
+++ b/main.go
@@ -82,7 +82,14 @@ func UpgradeProvider(ctx Context, name string) error {
 	if s, ok := ProviderName[upstreamProviderName]; ok {
 		upstreamProviderName = s
 	}
-	ok := step.Run(step.Combined("Discovering Repository",
+
+	ok := step.Run(step.Combined("Setting Up Environment",
+		step.Env("GOWORK", "off")))
+	if !ok {
+		return ErrHandled
+	}
+
+	ok = step.Run(step.Combined("Discovering Repository",
 		pulumiProviderRepos(ctx, name).AssignTo(&path),
 		pullDefaultBranch(ctx, "origin").In(&path).AssignTo(&defaultBranch),
 		step.F("Upgrade version", func() (string, error) {

--- a/step/step.go
+++ b/step/step.go
@@ -86,6 +86,13 @@ func Cmd(command *exec.Cmd) Step {
 	}).Return(&output)
 }
 
+// Set an environmental variable.
+func Env(key, value string) Step {
+	return F(fmt.Sprintf("%s=%q", key, value), func() (string, error) {
+		return "", os.Setenv(key, value)
+	})
+}
+
 // Assign the output value of the step a variable.
 func (s step) AssignTo(position *string) Step {
 	return step{


### PR DESCRIPTION
This adds a "Setting Up Environment" step, which we nest this under. This allows a user running the command to understand what the cli is doing under the hood. 