### PR TITLE
Error on missing docs, mirroring CI

### DIFF
--- a/main.go
+++ b/main.go
@@ -84,7 +84,9 @@ func UpgradeProvider(ctx Context, name string) error {
 	}
 
 	ok := step.Run(step.Combined("Setting Up Environment",
-		step.Env("GOWORK", "off")))
+		step.Env("GOWORK", "off"),
+		step.Env("PULUMI_MISSING_DOCS_ERROR", "true"),
+	))
 	if !ok {
 		return ErrHandled
 	}


### PR DESCRIPTION
This will prevent PRs like https://github.com/pulumi/pulumi-artifactory/pull/252 from going out broken. Since we set this during CI, we should set this when validating our build. 