### PR TITLE
Add `--upgrade-to=MAX_VERSION` flag

### DIFF
--- a/main.go
+++ b/main.go
@@ -233,7 +233,7 @@ func UpgradeProvider(ctx Context, name string) error {
 			step.Cmd(exec.CommandContext(ctx, "git", "add", "upstream")).In(&path),
 			// We re-apply changes, eagerly.
 			//
-			// Failure to perform this step can lead to failures later, For
+			// Failure to perform this step can lead to failures later, for
 			// example, wee might have a patched in shim dir that is not yet
 			// restored, causing `go mod tidy` to fail, even where `make
 			// provider` would succeed.


### PR DESCRIPTION
This allows the user to control the max version the script will target.

Specifically, this will allow a user to "finish off" the current major version before upgrading to the next major version.

https://github.com/pulumi/pulumi-aiven/pull/259 is an example PR generated after this change.