### PR TITLE
Automate most of a major version bump

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/pulumi/pulumi/sdk/v3 v3.53.1
 	github.com/spf13/cobra v1.6.1
 	golang.org/x/mod v0.6.0-dev.0.20220419223038-86c51ed26bb4
+	gopkg.in/yaml.v3 v3.0.1
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -50,6 +50,7 @@ golang.org/x/sys v0.0.0-20220823224334-20c2bfdbfe24 h1:TyKJRhyo17yWxOMCTHKWrc5rd
 golang.org/x/sys v0.0.0-20220823224334-20c2bfdbfe24/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.1.0 h1:g6Z6vPFA9dYBAF7DWcH6sCcOntplXsDKcliusYijMlw=
 golang.org/x/term v0.1.0/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=

--- a/main.go
+++ b/main.go
@@ -1113,6 +1113,10 @@ func majorVersionBump(ctx Context, repo ProviderRepo) step.Step {
 
 			}
 			err := filepath.Walk(*repo.providerDir(), fn)
+			if err != nil {
+				return "", err
+			}
+			err = filepath.Walk(filepath.Join(repo.root, "examples"), fn)
 			return fmt.Sprintf("Updated %d files", filesUpdated), err
 		}),
 		step.F("info.TFProviderModuleVersion", func() (string, error) {


### PR DESCRIPTION
This commit adds automation for steps 1..9 and step 11 of
https://github.com/pulumi/platform-providers-team/blob/main/playbooks/tf-provider-major-version-update.md.

There is a warning that the user needs to handle steps 10..12 on their own.


This is a quick and dirty version of #9, merged onto the new master. My goal is to get something usable as quickly as possible. We can then iterate on it as we hit bumps.