### PR TITLE
Correctly insert prefix version

### DIFF
--- a/main.go
+++ b/main.go
@@ -1144,7 +1144,8 @@ func majorVersionBump(ctx Context, repo ProviderRepo) step.Step {
 			if field == nil {
 				return "not present", nil
 			}
-			return "", fmt.Errorf("requires manual update")
+			// Escape codes are Bold, Yellow, and Reset respectively
+			return "\u001B[1m\u001B[33mrequires manual update\u001B[m", nil
 		}),
 		step.Env("VERSION_PREFIX", repo.currentVersion.IncMajor().String()),
 		addVersionPrefixToGHWorkflows(ctx, repo).In(&repo.root),

--- a/main.go
+++ b/main.go
@@ -1209,7 +1209,7 @@ func addVersionPrefixToGHWorkflows(ctx context.Context, repo ProviderRepo) step.
 			})
 		}
 
-		versionPrefix := fmt.Sprintf(`"%s"`, repo.currentVersion.IncMajor().String())
+		versionPrefix := repo.currentVersion.IncMajor().String()
 
 		var fixed bool
 		for i, child := range env.Content {


### PR DESCRIPTION
Fixes a couple of bugs I encountered testing upgrading the major version.

- https://github.com/pulumi/upgrade-provider/pull/16/commits/012ed59c1cb5acc960f4cb583192910510d3c11e PREFIX_VERSION was inserted into the wrong part of the file because there was an extra level of indirection in map nodes.
- https://github.com/pulumi/upgrade-provider/pull/16/commits/3d33b72f28048bfa6e3d71a2bdcb345a289873b9 We needed to alter the `go get ${UPSTREAM}/v${MAJORE}@${SHA}` to reflect the new major version.
- https://github.com/pulumi/upgrade-provider/pull/16/commits/1a66daca622d8d6d954af9e31bea6230bcf4599b Previously, the presence of `TFProviderModuleVersion` this would cause the workflow to stop. Now that the workflow tolerates "partial automation", we can turn this into a warning.
- https://github.com/pulumi/upgrade-provider/pull/16/commits/e1aa0f1f04d306a063613e70f8f009ed278ac553 We need to update references to the upstream provider, since they also contain a new major version.
- https://github.com/pulumi/upgrade-provider/pull/16/commits/898ded85713741434a579481416b6ddb32c074d9 Remove the double quote on the VERSION_PREFIX value.