### PR TITLE
Detect NoOp bridge and provider updates

### DIFF
--- a/colorize/colorize.go
+++ b/colorize/colorize.go
@@ -1,0 +1,16 @@
+package colorize
+
+const (
+	esc   = "\u001B["
+	bold  = esc + "1m"
+	warn  = bold + esc + "33m"
+	reset = esc + "m"
+)
+
+func Bold(s string) string {
+	return bold + s + reset
+}
+
+func Warn(s string) string {
+	return warn + s + reset
+}

--- a/main.go
+++ b/main.go
@@ -229,8 +229,9 @@ func UpgradeProvider(ctx Context, name string) error {
 					return fmt.Sprintf("Up to date at %s", latest.Original()), nil
 				}
 
-				return fmt.Sprintf("%s -> %s", latest.Original(), goMod.Bridge.Version), nil
-			}).AssignTo(&targetBridgeVersion))
+				targetBridgeVersion = latest.Original()
+				return fmt.Sprintf("%s -> %s", goMod.Bridge.Version, latest.Original()), nil
+			}))
 	}
 
 	if ctx.MajorVersionBump {
@@ -1133,7 +1134,6 @@ func majorVersionBump(ctx Context, goMod *GoMod, targets UpstreamVersions, repo 
 			"github.com/pulumi/"+name+"/{}/pkg").In(&repo.root),
 		replaceInFile("Update Go Module", "go.mod",
 			"module github.com/pulumi/"+name+"/{}").In(repo.providerDir()),
-		step.Cmd(exec.CommandContext(ctx, "go", "mod", "tidy")).In(repo.providerDir()),
 		step.F("Update Go Imports", func() (string, error) {
 			var filesUpdated int
 			var fn filepath.WalkFunc = func(path string, info fs.FileInfo, err error) error {

--- a/main.go
+++ b/main.go
@@ -203,7 +203,7 @@ func UpgradeProvider(ctx Context, name string) error {
 				// Otherwise, we don't bother to try to upgrade the provider.
 				ctx.UpgradeProviderVersion = false
 				ctx.MajorVersionBump = false
-				return msg, nil
+				return "Up to date" + msg, nil
 			}))
 	}
 
@@ -226,7 +226,7 @@ func UpgradeProvider(ctx Context, name string) error {
 				// If our target upgrade version is the same as our current version, we skip the update.
 				if latest.Original() == goMod.Bridge.Version {
 					ctx.UpgradeBridgeVersion = false
-					return fmt.Sprintf("Fully up to date at %s", latest.Original()), nil
+					return fmt.Sprintf("Up to date at %s", latest.Original()), nil
 				}
 
 				return fmt.Sprintf("%s -> %s", latest.Original(), goMod.Bridge.Version), nil
@@ -678,7 +678,7 @@ func getExpectedTarget(ctx Context, name string) ([]UpgradeTargetIssue, string, 
 		if versionConstrained {
 			extra = " (a version was found but it was greater then the specified max)"
 		}
-		return nil, fmt.Sprintf("no upgrade found%s", extra), nil
+		return nil, extra, nil
 	}
 	sort.Slice(versions, func(i, j int) bool {
 		return versions[j].Version.LessThan(versions[i].Version)


### PR DESCRIPTION
`upgrade-provider` will no detect the current version of the bridge before it attempts to upgrade the bridge. If the current and target bridge version match, it will not attempt the update.

This also PR changes the behavior when attempting to update a provider version, but no version is detected. Instead of erroring, it succeeds.

If no action is needed, `upgrade-provider` will stop at the discovery step:

```
$ upgrade-provider pulumi-databricks
---- Setting Up Environment ----
- ✓ GOWORK="off": done
- ✓ PULUMI_MISSING_DOCS_ERROR="true": done
---- Discovering Repository ----
- Ensure 'github.com/pulumi/pulumi-databricks'
  - ✓ Expected Location: /Users/ianwahbe/go/src/github.com/pulumi/pulumi-databricks
  - ✓ Downloading: skipped
  - ✓ Validating: done
- pull default branch
  - ✓ /usr/local/bin/git ls-remote --heads origin: done
  - ✓ finding default branch: main
  - ✓ /usr/local/bin/git checkout main: done
  - ✓ /usr/local/bin/git pull origin: done
- ✓ Target Provider Version: Up to date
- ✓ Repo kind: plain
- ✓ Planning Bridge Update: Up to date at v3.42.1
No actions needed (in bold, but it doesn't appear you can bold text within a markdown block)
```

Normally `upgrade-provider pulumi-databricks` would attempt both a provider and bridge update.

---

This will enable firing `upgrade-provider --kind=bridge pulumi-${PROVIDER}` in a loop against all of our providers. Providers that need an update will get one. Providers that don't need an update won't have a PR set up.