### PR TITLE
Set up tag based release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,24 @@
+name: release
+on:
+  push:
+    tags: [ "v*.[0-99]" ] # only a valid semver tag
+
+jobs:
+  goreleaser:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Unshallow clone
+        run: git fetch --prune --unshallow --tags
+      - name: Install Go 1.20
+        uses: actions/setup-go@v2
+        with:
+          go-version: '1.20.x'
+      - name: Goreleaser publish
+        uses: goreleaser/goreleaser-action@v2
+        with:
+          version: latest
+          args: release --rm-dist
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,23 @@
+builds:
+  - env:
+      - CGO_ENABLED=0
+    goos:
+      - linux
+      - windows
+      - darwin
+    goarch:
+      - amd64
+      - arm64
+    binary: upgrade-provider
+    main: ./main.go
+archives:
+  - name_template: "{{ .Binary }}-{{ .Tag }}-{{ .Os }}-{{ .Arch }}"
+    format_overrides:
+      - goos: windows
+        format: zip
+checksum:
+  name_template: 'checksums.txt'
+snapshot:
+  name_template: "{{ .Tag }}-next"
+changelog:
+  use: github


### PR DESCRIPTION
I'm doing this so we can version downstream CI consumers (when we have downstream CI consumers).

The contents of the action is based on [schema-tools](https://github.com/pulumi/schema-tools/blob/e3106cb65dbde7c8f0646ca4110600415bdd9673/.goreleaser.yml#L1-L25).