### PR TITLE
Allow phony SHA1 commits during tag lookup

### DIFF
--- a/main.go
+++ b/main.go
@@ -1404,16 +1404,15 @@ func setCurrentUpstreamFromPatched(ctx Context, repo *ProviderRepo) error {
 			continue
 		}
 		ref := string(bytes.Split(bytes.TrimSpace(tag), []byte{'\t'})[1])
-		version = strings.TrimPrefix(ref, "refs/tags/")
+		version = strings.TrimSpace(strings.TrimSuffix(strings.TrimPrefix(ref, "refs/tags/"), "^{}"))
 	}
 	if version == "" {
 		return fmt.Errorf("No tags match expected SHA '%s'", string(sha))
 	}
 
-	repo.currentUpstreamVersion, err =
-		semver.NewVersion(strings.TrimSpace(version))
+	repo.currentUpstreamVersion, err = semver.NewVersion(version)
 	if err != nil {
-		return fmt.Errorf("current upstream version: %w", err)
+		return fmt.Errorf("current upstream version '%s': %w", version, err)
 	}
 	return nil
 }


### PR DESCRIPTION
Git appends certain SHA1 commits with "^{}" to indicate that they could be tag commits, and that the commit can be *dereferenced*. We are perfectly happy to use such commits here (since we are tag hunting anyway), so we remove the trailing "^{}".