### PR TITLE
Detect previous upstream versions (continued)

### DIFF
--- a/main.go
+++ b/main.go
@@ -1401,6 +1401,13 @@ func setCurrentUpstreamFromPatched(ctx Context, repo *ProviderRepo) error {
 	}
 	sha := bytes.TrimSpace(checkedInCommit)
 
+	ensureSubmoduleInit := exec.CommandContext(ctx,
+		"git", "submodule", "init")
+	ensureSubmoduleInit.Dir = repo.root
+	out, err := ensureSubmoduleInit.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("failed to init submodule: %w: %s", err, string(out))
+	}
 	getRemoteURL := exec.CommandContext(ctx,
 		"git", "config", "--get", "submodule.upstream.url")
 	getRemoteURL.Dir = repo.root

--- a/main.go
+++ b/main.go
@@ -276,13 +276,15 @@ func UpgradeProvider(ctx Context, name string) error {
 		return ErrHandled
 	}
 
-	shouldMajorVersionBump := repo.currentUpstreamVersion.Major() != upgradeTargets.Latest().Major()
-	if ctx.MajorVersionBump && !shouldMajorVersionBump {
-		return fmt.Errorf("--major version update indicated, but no major upgrade available (already on v%d)",
-			repo.currentUpstreamVersion.Major())
-	} else if !ctx.MajorVersionBump && shouldMajorVersionBump {
-		return fmt.Errorf("This is a major version update (v%d -> v%d), but --major was not passed",
-			repo.currentUpstreamVersion.Major(), upgradeTargets.Latest().Major())
+	if ctx.UpgradeProviderVersion {
+		shouldMajorVersionBump := repo.currentUpstreamVersion.Major() != upgradeTargets.Latest().Major()
+		if ctx.MajorVersionBump && !shouldMajorVersionBump {
+			return fmt.Errorf("--major version update indicated, but no major upgrade available (already on v%d)",
+				repo.currentUpstreamVersion.Major())
+		} else if !ctx.MajorVersionBump && shouldMajorVersionBump {
+			return fmt.Errorf("This is a major version update (v%d -> v%d), but --major was not passed",
+				repo.currentUpstreamVersion.Major(), upgradeTargets.Latest().Major())
+		}
 	}
 
 	// Running the discover steps might have invalidated one or more actions. If there


### PR DESCRIPTION
Ensure that we have detected the previous upstream provider version correctly in all cases.

We already handled plain and patched providers. This PR adds forked and shimmed support, bringing upstream version detection to full capability.