### PR TITLE
Add code migration option/ automate adding `AutoAliasing` 

### DIFF
--- a/main.go
+++ b/main.go
@@ -1744,6 +1744,7 @@ func AddAutoAliasing(ctx Context, repo ProviderRepo, providerName string) (step.
 	)
 
 	return step.Combined("Add AutoAliasing", steps...), nil
+}
 
 // Most if not all of our TF SDK based providers use a "replace" based version of
 // github.com/hashicorp/terraform-plugin-sdk/v2. To avoid compile errors, we want


### PR DESCRIPTION
This PR adds an option to perform code migrations on providers, either alongside a normal provider updates (by default or if `--kind=all`), or by itself (if `--kind=code`). 
If `--kind=all`, all available code migrations options will be performed.
If `--kind=code`, a list of options must be specified via `--migration-opts`.

Currently the only option is to add `AutoAliasing`.