### PR TITLE
Add AutoAliasing code migration

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,18 +7,21 @@ require (
 	github.com/briandowns/spinner v1.20.0
 	github.com/pulumi/pulumi/sdk/v3 v3.53.1
 	github.com/spf13/cobra v1.6.1
+	github.com/stretchr/testify v1.8.1
 	golang.org/x/mod v0.6.0-dev.0.20220419223038-86c51ed26bb4
+	golang.org/x/tools v0.0.0-20191119224855-298f0cb1881e
 	gopkg.in/yaml.v3 v3.0.1
 )
 
 require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/fatih/color v1.13.0 // indirect
 	github.com/golang/glog v1.0.0 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/mattn/go-colorable v0.1.12 // indirect
 	github.com/mattn/go-isatty v0.0.14 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
-	github.com/stretchr/testify v1.8.1 // indirect
 	golang.org/x/sys v0.0.0-20220823224334-20c2bfdbfe24 // indirect
 	golang.org/x/term v0.1.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -38,8 +38,12 @@ github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/stretchr/testify v1.8.1 h1:w7B6lhMri9wdJUVmEZPGGhZzrYTPvgJArz7wNPgYKsk=
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
+golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/mod v0.6.0-dev.0.20220419223038-86c51ed26bb4 h1:6zppjxzCulZykYSLyVDYbneBfbaBIQPYMevg0bEwv2s=
 golang.org/x/mod v0.6.0-dev.0.20220419223038-86c51ed26bb4/go.mod h1:jJ57K6gSWd91VN4djpZkiMVwK6gcyfeH4XE8wZrZaV4=
+golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
+golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190222072716-a9d3bda3a223/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20200116001909-b77594299b42/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200223170610-d5e6a3e2c0ae/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
@@ -50,6 +54,10 @@ golang.org/x/sys v0.0.0-20220823224334-20c2bfdbfe24 h1:TyKJRhyo17yWxOMCTHKWrc5rd
 golang.org/x/sys v0.0.0-20220823224334-20c2bfdbfe24/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.1.0 h1:g6Z6vPFA9dYBAF7DWcH6sCcOntplXsDKcliusYijMlw=
 golang.org/x/term v0.1.0/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=
+golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
+golang.org/x/tools v0.0.0-20191119224855-298f0cb1881e h1:aZzprAO9/8oim3qStq3wc1Xuxx4QmAGriC4VU4ojemQ=
+golang.org/x/tools v0.0.0-20191119224855-298f0cb1881e/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
+golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/main.go
+++ b/main.go
@@ -57,13 +57,16 @@ func cmd() *cobra.Command {
 			case "all":
 				context.UpgradeBridgeVersion = true
 				context.UpgradeProviderVersion = true
+				context.UpgradeCodeMigration = true
 			case "bridge":
 				context.UpgradeBridgeVersion = true
 			case "provider":
 				context.UpgradeProviderVersion = true
+			case "code":
+				context.UpgradeCodeMigration = true
 			default:
 				return fmt.Errorf(
-					"--kind=%s invalid. Must be one of `all`, `bridge` or `provider`.",
+					"--kind=%s invalid. Must be one of `all`, `bridge`, `provider`, or `code`.",
 					upgradeKind)
 			}
 
@@ -92,7 +95,12 @@ If the passed version does not exist, an error is signaled.`)
 		`The kind of upgrade to perform:
 - "all":     Upgrade the upstream provider and the bridge.
 - "bridge":  Upgrade the bridge only.
-- "provider: Upgrade the upstream provider only.`)
+- "provider: Upgrade the upstream provider only.
+- "code":     Perform some number of code migrations.`)
+
+	cmd.PersistentFlags().StringSliceVar(&context.MigrationOpts, "migration-opts", nil,
+		`A comma separated list of code migration to perform:
+- "autoalias": Apply auto aliasing to the provider.`)
 
 	return cmd
 }

--- a/upgrade/migrations.go
+++ b/upgrade/migrations.go
@@ -162,7 +162,7 @@ func AutoAliasingMigration(resourcesFilePath, providerName string) error {
 	if err != nil {
 		return err
 	}
-	s := string(buf.Bytes())
+	s := buf.String()
 	s = strings.Replace(s, `EMBED_COMMENT_ANCHOR "embed"`,
 		"// embed is used to store bridge-metadata.json in the compiled binary\n    _ \"embed\"", 1)
 	s = strings.Replace(s, `var metadata []byte // EMBED_DIRECTIVE_ANCHOR`,

--- a/upgrade/migrations.go
+++ b/upgrade/migrations.go
@@ -1,0 +1,162 @@
+package upgrade
+
+import (
+	"fmt"
+	"go/ast"
+	"go/format"
+	"go/printer"
+	"go/token"
+	"os"
+	"strings"
+
+	"golang.org/x/tools/go/ast/astutil"
+)
+
+const (
+	TfBridgeXPkg = "github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge/x"
+	ContractPkg  = "github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
+)
+
+func AutoAliasingMigration(fset *token.FileSet, file *ast.File, savePath, providerName string) (bool, error) {
+	changesMade := false
+
+	changesMade = astutil.AddImport(fset, file, TfBridgeXPkg)
+	changesMade = astutil.AddImport(fset, file, ContractPkg) || changesMade
+	changesMade = astutil.AddNamedImport(fset, file, "_", "embed") || changesMade
+
+	applied, errAssigned := false, false
+	astutil.Apply(file, nil, func(c *astutil.Cursor) bool {
+		n := c.Node()
+		switch x := n.(type) {
+		case *ast.ImportSpec:
+			if x.Path.Value == "\"embed\"" {
+				x.Comment = &ast.CommentGroup{List: []*ast.Comment{
+					{Text: "embed package not used directly"},
+				}}
+				c.Replace(x)
+			}
+		case *ast.CompositeLit:
+			if s, ok := x.Type.(*ast.SelectorExpr); ok && s.Sel.Name == "ProviderInfo" {
+				x.Elts = append(x.Elts, &ast.KeyValueExpr{
+					Key: &ast.Ident{Name: "MetadataInfo"},
+					Value: &ast.CallExpr{
+						Fun: &ast.SelectorExpr{
+							X:   &ast.Ident{Name: "tfbridge"},
+							Sel: &ast.Ident{Name: "NewProviderMetadata"},
+						},
+						Args: []ast.Expr{&ast.Ident{Name: "metadata"}},
+					},
+				})
+			}
+		case *ast.AssignStmt:
+			for _, l := range x.Lhs {
+				if e, ok := l.(*ast.Ident); ok && e.Name == "err" {
+					errAssigned = true
+				}
+			}
+			if len(x.Rhs) == 1 {
+				if c, ok := x.Rhs[0].(*ast.CallExpr); ok {
+					if s, ok := c.Fun.(*ast.SelectorExpr); ok && s.Sel.Name == "AutoAliasing" {
+						applied = true
+						return true
+					}
+				}
+			}
+		case *ast.ExprStmt:
+			var id *ast.SelectorExpr
+			call, ok := x.X.(*ast.CallExpr)
+			if ok {
+				id, ok = call.Fun.(*ast.SelectorExpr)
+			}
+			if ok {
+				if id.Sel.Name == "SetAutonaming" && !applied {
+					tok := token.DEFINE
+					if errAssigned {
+						tok = token.ASSIGN
+					}
+					c.InsertBefore(&ast.AssignStmt{
+						Tok: tok,
+						Lhs: []ast.Expr{&ast.Ident{Name: "err", Obj: &ast.Object{Kind: ast.Var, Name: "err"}}},
+						Rhs: []ast.Expr{&ast.CallExpr{
+							Fun: &ast.SelectorExpr{
+								X:   &ast.Ident{Name: "x"},
+								Sel: &ast.Ident{Name: "AutoAliasing"},
+							},
+							Args: []ast.Expr{
+								&ast.UnaryExpr{
+									Op: token.AND,
+									X:  &ast.Ident{Name: "prov", Obj: &ast.Object{Kind: ast.Var, Name: "prov"}},
+								},
+								&ast.CallExpr{
+									Fun: &ast.SelectorExpr{
+										X:   &ast.Ident{Name: "prov", Obj: &ast.Object{Kind: ast.Var, Name: "prov"}},
+										Sel: &ast.Ident{Name: "GetMetadata"},
+									},
+								},
+							},
+						}},
+					})
+					c.InsertBefore(&ast.ExprStmt{
+						X: &ast.CallExpr{
+							Fun: &ast.SelectorExpr{
+								X:   &ast.Ident{Name: "contract"},
+								Sel: &ast.Ident{Name: "AssertNoErrorf"},
+							},
+							Args: []ast.Expr{
+								&ast.Ident{Name: "err", Obj: &ast.Object{Kind: ast.Var, Name: "err"}},
+								&ast.BasicLit{Kind: token.STRING, Value: "\"auto aliasing apply failed\""},
+							},
+						}})
+					changesMade = true
+				}
+			}
+		}
+
+		return true
+	})
+
+	file.Decls = append(file.Decls, &ast.GenDecl{
+		// Doc: &ast.CommentGroup{
+		// 	List: []*ast.Comment{
+		// 		{Text: "go:embed cmd/pulumi-resource-databricks/bridge-metadata.json"},
+		// 	},
+		// },
+		Tok: token.VAR,
+		Specs: []ast.Spec{
+			&ast.ValueSpec{
+				Names: []*ast.Ident{{Name: "metadata", Obj: &ast.Object{Kind: ast.Var, Name: "metadata"}}},
+				Type:  &ast.ArrayType{Elt: &ast.Ident{Name: "byte"}},
+			},
+		},
+	})
+
+	out, err := os.Create(savePath)
+	if err != nil {
+		return false, err
+	}
+	err = printer.Fprint(out, fset, file)
+	if err != nil {
+		return false, err
+	}
+
+	b, err := os.ReadFile(savePath)
+	if err != nil {
+		return false, err
+	}
+	lines := strings.Split(string(b), "\n")
+	for i, line := range lines {
+		if strings.Contains(line, `_ "embed"`) {
+			lines[i] = "    // embed package blank import\n" + lines[i]
+		} else if strings.Contains(line, "var metadata []byte") {
+			lines[i] = fmt.Sprintf("//go:embed cmd/pulumi-resource-%s/bridge-metadata.json\n", providerName) + lines[i]
+		}
+	}
+	b = []byte(strings.Join(lines, "\n"))
+	formatted, err := format.Source(b)
+	if err != nil {
+		return false, err
+	}
+	err = os.WriteFile(savePath, formatted, 0600)
+
+	return changesMade, err
+}

--- a/upgrade/migrations.go
+++ b/upgrade/migrations.go
@@ -1,9 +1,11 @@
 package upgrade
 
 import (
+	"bytes"
 	"fmt"
 	"go/ast"
 	"go/format"
+	"go/parser"
 	"go/printer"
 	"go/token"
 	"os"
@@ -17,23 +19,54 @@ const (
 	ContractPkg  = "github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 )
 
-func AutoAliasingMigration(fset *token.FileSet, file *ast.File, savePath, providerName string) (bool, error) {
-	changesMade := false
+func AutoAliasingMigration(resourcesFilePath, providerName string) error {
+	// Create the AST by parsing src
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, resourcesFilePath, nil, parser.ParseComments)
+	if err != nil {
+		return err
+	}
 
-	changesMade = astutil.AddImport(fset, file, TfBridgeXPkg)
-	changesMade = astutil.AddImport(fset, file, ContractPkg) || changesMade
-	changesMade = astutil.AddNamedImport(fset, file, "_", "embed") || changesMade
-
-	applied, errAssigned := false, false
+	applied, initMetadata, errAssigned := false, true, false
+	// check to see if already implemented
 	astutil.Apply(file, nil, func(c *astutil.Cursor) bool {
 		n := c.Node()
 		switch x := n.(type) {
-		case *ast.ImportSpec:
-			if x.Path.Value == "\"embed\"" {
-				x.Comment = &ast.CommentGroup{List: []*ast.Comment{
-					{Text: "embed package not used directly"},
-				}}
-				c.Replace(x)
+		case *ast.AssignStmt:
+			if len(x.Rhs) == 1 {
+				if c, ok := x.Rhs[0].(*ast.CallExpr); ok {
+					if s, ok := c.Fun.(*ast.SelectorExpr); ok && s.Sel.Name == "AutoAliasing" {
+						applied = true
+						return true
+					}
+				}
+			}
+		}
+		return true
+	})
+	if applied {
+		return nil
+	}
+
+	astutil.AddImport(fset, file, TfBridgeXPkg)
+	astutil.AddImport(fset, file, ContractPkg)
+	astutil.AddNamedImport(fset, file, "EMBED_COMMENT_ANCHOR", "embed")
+
+	astutil.Apply(file, nil, func(c *astutil.Cursor) bool {
+		n := c.Node()
+		switch x := n.(type) {
+		// case *ast.ImportSpec:
+		// 	if x.Path.Value == "\"embed\"" {
+		// 		x.Comment = &ast.CommentGroup{List: []*ast.Comment{
+		// 			{Text: "embed package not used directly"},
+		// 		}}
+		// 		c.Replace(x)
+		// 	}
+		case *ast.GenDecl:
+			if x.Tok == token.VAR {
+				if s, ok := x.Specs[0].(*ast.ValueSpec); ok && s.Names[0].Name == "metadata" {
+					initMetadata = false
+				}
 			}
 		case *ast.CompositeLit:
 			if s, ok := x.Type.(*ast.SelectorExpr); ok && s.Sel.Name == "ProviderInfo" {
@@ -54,14 +87,6 @@ func AutoAliasingMigration(fset *token.FileSet, file *ast.File, savePath, provid
 					errAssigned = true
 				}
 			}
-			if len(x.Rhs) == 1 {
-				if c, ok := x.Rhs[0].(*ast.CallExpr); ok {
-					if s, ok := c.Fun.(*ast.SelectorExpr); ok && s.Sel.Name == "AutoAliasing" {
-						applied = true
-						return true
-					}
-				}
-			}
 		case *ast.ExprStmt:
 			var id *ast.SelectorExpr
 			call, ok := x.X.(*ast.CallExpr)
@@ -69,7 +94,7 @@ func AutoAliasingMigration(fset *token.FileSet, file *ast.File, savePath, provid
 				id, ok = call.Fun.(*ast.SelectorExpr)
 			}
 			if ok {
-				if id.Sel.Name == "SetAutonaming" && !applied {
+				if id.Sel.Name == "SetAutonaming" {
 					tok := token.DEFINE
 					if errAssigned {
 						tok = token.ASSIGN
@@ -107,7 +132,6 @@ func AutoAliasingMigration(fset *token.FileSet, file *ast.File, savePath, provid
 								&ast.BasicLit{Kind: token.STRING, Value: "\"auto aliasing apply failed\""},
 							},
 						}})
-					changesMade = true
 				}
 			}
 		}
@@ -115,49 +139,41 @@ func AutoAliasingMigration(fset *token.FileSet, file *ast.File, savePath, provid
 		return true
 	})
 
-	file.Decls = append(file.Decls, &ast.GenDecl{
-		// Doc: &ast.CommentGroup{
-		// 	List: []*ast.Comment{
-		// 		{Text: "go:embed cmd/pulumi-resource-databricks/bridge-metadata.json"},
-		// 	},
-		// },
-		Tok: token.VAR,
-		Specs: []ast.Spec{
-			&ast.ValueSpec{
-				Names: []*ast.Ident{{Name: "metadata", Obj: &ast.Object{Kind: ast.Var, Name: "metadata"}}},
-				Type:  &ast.ArrayType{Elt: &ast.Ident{Name: "byte"}},
-			},
-		},
-	})
-
-	out, err := os.Create(savePath)
-	if err != nil {
-		return false, err
-	}
-	err = printer.Fprint(out, fset, file)
-	if err != nil {
-		return false, err
-	}
-
 	// TODO: figure out how to properly append comments so everything can be done via AST manipulation
-	b, err := os.ReadFile(savePath)
-	if err != nil {
-		return false, err
+	if initMetadata {
+		file.Decls = append(file.Decls, &ast.GenDecl{
+			// Doc: &ast.CommentGroup{
+			// 	List: []*ast.Comment{
+			// 		{Text: "go:embed cmd/pulumi-resource-databricks/bridge-metadata.json"},
+			// 	},
+			// },
+			Tok: token.VAR,
+			Specs: []ast.Spec{
+				&ast.ValueSpec{
+					Names: []*ast.Ident{{Name: "metadata", Obj: &ast.Object{Kind: ast.Var, Name: "metadata"}}},
+					Type:  &ast.ArrayType{Elt: &ast.Ident{Name: "byte // EMBED_DIRECTIVE_ANCHOR"}},
+				},
+			},
+		})
 	}
-	lines := strings.Split(string(b), "\n")
-	for i, line := range lines {
-		if strings.Contains(line, `_ "embed"`) {
-			lines[i] = "    // embed package blank import\n" + lines[i]
-		} else if strings.Contains(line, "var metadata []byte") {
-			lines[i] = fmt.Sprintf("//go:embed cmd/pulumi-resource-%s/bridge-metadata.json\n", providerName) + lines[i]
-		}
-	}
-	b = []byte(strings.Join(lines, "\n"))
-	formatted, err := format.Source(b)
-	if err != nil {
-		return false, err
-	}
-	err = os.WriteFile(savePath, formatted, 0600)
 
-	return changesMade, err
+	buf := new(bytes.Buffer)
+	err = printer.Fprint(buf, fset, file)
+	if err != nil {
+		return err
+	}
+	s := string(buf.Bytes())
+	s = strings.Replace(s, `EMBED_COMMENT_ANCHOR "embed"`,
+		"// embed is used to store bridge-metadata.json in the compiled binary\n    _ \"embed\"", 1)
+	s = strings.Replace(s, `var metadata []byte // EMBED_DIRECTIVE_ANCHOR`,
+		fmt.Sprintf("//go:embed cmd/pulumi-resource-%s/bridge-metadata.json\nvar metadata []byte",
+			providerName), 1)
+	// format output
+	formatted, err := format.Source([]byte(s))
+	if err != nil {
+		return err
+	}
+	err = os.WriteFile(resourcesFilePath, formatted, 0600)
+
+	return err
 }

--- a/upgrade/migrations.go
+++ b/upgrade/migrations.go
@@ -139,6 +139,7 @@ func AutoAliasingMigration(fset *token.FileSet, file *ast.File, savePath, provid
 		return false, err
 	}
 
+	// TODO: figure out how to properly append comments so everything can be done via AST manipulation
 	b, err := os.ReadFile(savePath)
 	if err != nil {
 		return false, err

--- a/upgrade/migrations_test.go
+++ b/upgrade/migrations_test.go
@@ -3,7 +3,7 @@ package upgrade
 import (
 	"go/parser"
 	"go/token"
-	"io/ioutil"
+	"ioutil"
 	"os"
 	"testing"
 
@@ -59,7 +59,8 @@ func Provider() tfbridge.ProviderInfo {
 	orig, err := os.Create("original.go")
 	assert.Nil(t, err)
 	defer os.Remove("original.go")
-	orig.Write([]byte(origProgram))
+	_, err = orig.Write([]byte(origProgram))
+	assert.Nil(t, err)
 
 	// Parse to ast
 	fs := token.NewFileSet()

--- a/upgrade/migrations_test.go
+++ b/upgrade/migrations_test.go
@@ -1,0 +1,131 @@
+package upgrade
+
+import (
+	"go/parser"
+	"go/token"
+	"io/ioutil"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAutoAliasingMigration(t *testing.T) {
+	origProgram := `package test
+
+import (
+	"fmt"
+	"path/filepath"
+	"strings"
+	"unicode"
+
+	"github.com/mrparkers/terraform-test/provider"
+	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge"
+)
+
+// all of the token components used below.
+const (
+	// packages:
+	mainPkg = "test"
+	// modules:
+	mainMod           = "index"          // the y module
+)
+
+// Provider returns additional overlaid schema and metadata associated with the provider..
+func Provider() tfbridge.ProviderInfo {
+	// Instantiate the Terraform provider
+	p := shimv2.NewProvider(provider.KeycloakProvider(nil))
+
+	// Create a Pulumi provider mapping
+	prov := tfbridge.ProviderInfo{
+		P:                 p,
+		Name:              "test",
+		GitHubOrg:         "testing",
+		Description:       "A Pulumi package for creating and managing test cloud resources.",
+		Keywords:          []string{"pulumi", "test"},
+		License:           "Apache-2.0",
+		Homepage:          "https://pulumi.io",
+		Repository:        "https://github.com/pulumi/pulumi-keycloak",
+		TFProviderLicense: refProviderLicense(tfbridge.MITLicenseType),
+		UpstreamRepoPath:  ".",
+	}
+	prov.SetAutonaming(255, "-")
+
+	return prov
+}
+`
+
+	// Write original program to temporary file
+	orig, err := os.Create("original.go")
+	assert.Nil(t, err)
+	defer os.Remove("original.go")
+	orig.Write([]byte(origProgram))
+
+	// Parse to ast
+	fs := token.NewFileSet()
+	f, err := parser.ParseFile(fs, "original.go", nil, parser.DeclarationErrors|parser.ParseComments)
+	assert.Nil(t, err)
+
+	// Perform auto aliasing migration
+	_, err = AutoAliasingMigration(fs, f, "original.go", "test")
+	assert.Nil(t, err)
+
+	newProgram, err := ioutil.ReadFile("original.go")
+	assert.Nil(t, err)
+
+	expectedProgram := `package test
+
+import (
+	"fmt"
+	// embed package blank import
+	_ "embed"
+	"path/filepath"
+	"strings"
+	"unicode"
+
+	"github.com/mrparkers/terraform-test/provider"
+	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge"
+	"github.com/pulumi/pulumi-terraform-bridge/v3/pkg/tfbridge/x"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
+)
+
+// all of the token components used below.
+const (
+	// packages:
+	mainPkg = "test"
+	// modules:
+	mainMod = "index" // the y module
+)
+
+// Provider returns additional overlaid schema and metadata associated with the provider..
+func Provider() tfbridge.ProviderInfo {
+	// Instantiate the Terraform provider
+	p := shimv2.NewProvider(provider.KeycloakProvider(nil))
+
+	// Create a Pulumi provider mapping
+	prov := tfbridge.ProviderInfo{
+		P:                 p,
+		Name:              "test",
+		GitHubOrg:         "testing",
+		Description:       "A Pulumi package for creating and managing test cloud resources.",
+		Keywords:          []string{"pulumi", "test"},
+		License:           "Apache-2.0",
+		Homepage:          "https://pulumi.io",
+		Repository:        "https://github.com/pulumi/pulumi-keycloak",
+		TFProviderLicense: refProviderLicense(tfbridge.MITLicenseType),
+		UpstreamRepoPath:  ".", MetadataInfo: tfbridge.NewProviderMetadata(metadata),
+	}
+	err := x.AutoAliasing(&prov, prov.GetMetadata())
+	contract.AssertNoErrorf(err, "auto aliasing apply failed")
+	prov.SetAutonaming(255, "-")
+
+	return prov
+}
+
+//go:embed cmd/pulumi-resource-test/bridge-metadata.json
+var metadata []byte
+`
+	// Compare against expected program
+	assert.Equal(t, newProgram, []byte(expectedProgram))
+
+}

--- a/upgrade/migrations_test.go
+++ b/upgrade/migrations_test.go
@@ -1,7 +1,6 @@
 package upgrade
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -66,7 +65,7 @@ func Provider() tfbridge.ProviderInfo {
 	err = AutoAliasingMigration(origPath, "test")
 	assert.Nil(t, err)
 
-	modified, err := ioutil.ReadFile(origPath)
+	modified, err := os.ReadFile(origPath)
 	assert.Nil(t, err)
 
 	expected := `package test
@@ -128,6 +127,8 @@ var metadata []byte
 	err = AutoAliasingMigration(origPath, "test")
 	assert.Nil(t, err)
 
-	modified2, err := ioutil.ReadFile(origPath)
+	modified2, err := os.ReadFile(origPath)
+	assert.Nil(t, err)
+
 	assert.Equal(t, string(modified2), expected)
 }

--- a/upgrade/migrations_test.go
+++ b/upgrade/migrations_test.go
@@ -62,8 +62,9 @@ func Provider() tfbridge.ProviderInfo {
 	assert.Nil(t, err)
 
 	// Perform auto aliasing migration
-	err = AutoAliasingMigration(origPath, "test")
+	changesMade, err := AutoAliasingMigration(origPath, "test")
 	assert.Nil(t, err)
+	assert.True(t, changesMade)
 
 	modified, err := os.ReadFile(origPath)
 	assert.Nil(t, err)
@@ -124,8 +125,9 @@ var metadata []byte
 	assert.Equal(t, string(modified), expected)
 
 	// Test running AutoAliasing twice doesn't change output
-	err = AutoAliasingMigration(origPath, "test")
+	changesMade, err = AutoAliasingMigration(origPath, "test")
 	assert.Nil(t, err)
+	assert.False(t, changesMade)
 
 	modified2, err := os.ReadFile(origPath)
 	assert.Nil(t, err)

--- a/upgrade/steps.go
+++ b/upgrade/steps.go
@@ -292,6 +292,8 @@ func InformGitHub(
 			upstreamProviderName, target.Latest())
 	} else if ctx.UpgradeBridgeVersion {
 		prTitle = "Upgrade pulumi-terraform-bridge to " + targetBridgeVersion
+	} else if ctx.UpgradeCodeMigration {
+		prTitle = fmt.Sprintf("Code migration: %s", strings.Join(ctx.MigrationOpts, ", "))
 	} else {
 		panic("Unknown action")
 	}

--- a/upgrade/util.go
+++ b/upgrade/util.go
@@ -20,6 +20,9 @@ type Context struct {
 
 	UpgradeProviderVersion bool
 	MajorVersionBump       bool
+
+	UpgradeCodeMigration bool
+	MigrationOpts        []string
 }
 
 type HandledError struct{}


### PR DESCRIPTION
This PR adds an option to perform code migrations on providers, either alongside a normal provider updates (by default or if --kind=all), or by itself (if --kind=code).
If --kind=all, all available code migrations options will be performed.
If --kind=code, a list of options must be specified via --migration-opts.

Currently the only option is to add AutoAliasing.