### PR TITLE
AssertNoError migration

### DIFF
--- a/upgrade/migrations.go
+++ b/upgrade/migrations.go
@@ -167,3 +167,55 @@ func AutoAliasingMigration(resourcesFilePath, providerName string) (bool, error)
 	}
 	return true, nil
 }
+
+func AssertNoErrorMigration(resourcesFilePath string) (bool, error) {
+	// Create the AST by parsing src
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, resourcesFilePath, nil, parser.ParseComments)
+	if err != nil {
+		return false, err
+	}
+
+	changesMade := false
+	astutil.Apply(file, nil, func(c *astutil.Cursor) bool {
+		n := c.Node()
+		switch x := n.(type) {
+		case *ast.CallExpr:
+			if s, ok := x.Fun.(*ast.SelectorExpr); ok {
+				if s.Sel.Name == "AssertNoError" {
+					changesMade = true
+					c.Replace(&ast.CallExpr{
+						Fun: &ast.SelectorExpr{
+							X:   &ast.Ident{Name: "contract"},
+							Sel: &ast.Ident{Name: "AssertNoErrorf"},
+						},
+						Args: []ast.Expr{
+							&ast.Ident{Name: "err", Obj: &ast.Object{Kind: ast.Var, Name: "err"}},
+							&ast.BasicLit{Kind: token.STRING, Value: "\"failed to apply auto token mapping\""},
+						},
+					})
+				}
+			}
+		}
+
+		return true
+	})
+	if !changesMade {
+		return false, nil
+	}
+	buf := new(bytes.Buffer)
+	err = printer.Fprint(buf, fset, file)
+	if err != nil {
+		return false, err
+	}
+	// format output
+	formatted, err := format.Source(buf.Bytes())
+	if err != nil {
+		return false, err
+	}
+	err = os.WriteFile(resourcesFilePath, formatted, 0600)
+	if err != nil {
+		return false, err
+	}
+	return changesMade, err
+}

--- a/upgrade/migrations_test.go
+++ b/upgrade/migrations_test.go
@@ -134,3 +134,47 @@ var metadata []byte
 
 	assert.Equal(t, string(modified2), expected)
 }
+
+func TestAssertNoErrorMigration(t *testing.T) {
+	origProgram := `package test
+
+import (
+	"os"
+)
+
+func testing() {
+    f, err := os.Open("path")
+    contract.AssertNoError(err)
+}
+`
+
+	// Write original program to temporary file
+	tmpDir := t.TempDir()
+	origPath := filepath.Join(tmpDir, "original.go")
+	orig, err := os.Create(origPath)
+	assert.Nil(t, err)
+	_, err = orig.Write([]byte(origProgram))
+	assert.Nil(t, err)
+
+	// Perform AssertNoError migration
+	changesMade, err := AssertNoErrorMigration(origPath)
+	assert.Nil(t, err)
+	assert.True(t, changesMade)
+
+	modified, err := os.ReadFile(origPath)
+	assert.Nil(t, err)
+
+	expected := `package test
+
+import (
+	"os"
+)
+
+func testing() {
+	f, err := os.Open("path")
+	contract.AssertNoErrorf(err, "failed to apply auto token mapping")
+}
+`
+	// Compare against expected program
+	assert.Equal(t, string(modified), expected)
+}

--- a/upgrade/migrations_test.go
+++ b/upgrade/migrations_test.go
@@ -157,7 +157,7 @@ func testing() {
 	assert.Nil(t, err)
 
 	// Perform AssertNoError migration
-	changesMade, err := AssertNoErrorMigration(origPath)
+	changesMade, err := AssertNoErrorMigration(origPath, "test")
 	assert.Nil(t, err)
 	assert.True(t, changesMade)
 
@@ -173,6 +173,7 @@ import (
 func testing() {
 	f, err := os.Open("path")
 	contract.AssertNoErrorf(err, "failed to apply auto token mapping")
+
 }
 `
 	// Compare against expected program

--- a/upgrade/steps.go
+++ b/upgrade/steps.go
@@ -809,20 +809,14 @@ func UpdateFile(desc, path string, f func([]byte) ([]byte, error)) step.Step {
 	})
 }
 
-func AddAutoAliasing(ctx Context, repo ProviderRepo, providerName string) (step.Step, error) {
+func migrationSteps(ctx Context, repo ProviderRepo, providerName string, description string,
+	migrationFunc func(resourcesFilePath, providerName string) (bool, error)) (step.Step, error) {
 	steps := []step.Step{}
 	providerName = strings.TrimPrefix(providerName, "pulumi-")
-	metadataPath := fmt.Sprintf("%s/cmd/pulumi-resource-%s/bridge-metadata.json", *repo.providerDir(), providerName)
 	changesMade := false
 	steps = append(steps,
-		step.F("Implement AutoAliasing", func() (string, error) {
-			if _, err := os.Stat(metadataPath); os.IsNotExist(err) {
-				_, err = os.Create(metadataPath)
-				if err != nil {
-					return "failed to initialize metadata file", err
-				}
-			}
-			changes, err := AutoAliasingMigration(filepath.Join(*repo.providerDir(), "resources.go"), providerName)
+		step.F(description, func() (string, error) {
+			changes, err := migrationFunc(filepath.Join(*repo.providerDir(), "resources.go"), providerName)
 			if err != nil {
 				return "failed to perform auto aliasing migration", err
 			}
@@ -832,7 +826,6 @@ func AddAutoAliasing(ctx Context, repo ProviderRepo, providerName string) (step.
 	if changesMade {
 		steps = append(steps,
 			step.Cmd(exec.CommandContext(ctx, "gofmt", "-s", "-w", "resources.go")).In(repo.providerDir()),
-			step.Cmd(exec.CommandContext(ctx, "git", "add", metadataPath)).In(&repo.root),
 			step.Cmd(exec.CommandContext(ctx, "git", "add", "resources.go")).In(&repo.root),
 			step.Cmd(exec.CommandContext(ctx, "git", "commit", "-m", "code migration")).In(&repo.root),
 		)
@@ -841,24 +834,19 @@ func AddAutoAliasing(ctx Context, repo ProviderRepo, providerName string) (step.
 	return step.Combined("Add AutoAliasing", steps...), nil
 }
 
-func ReplaceAssertNoError(ctx Context, repo ProviderRepo, providerName string) (step.Step, error) {
+func AddAutoAliasing(ctx Context, repo ProviderRepo, providerName string) (step.Step, error) {
 	steps := []step.Step{}
-	changesMade := false
-	steps = append(steps,
-		step.F("Replace AssertNoError", func() (string, error) {
-			changes, err := AssertNoErrorMigration(filepath.Join(*repo.providerDir(), "resources.go"))
-			if err != nil {
-				return "failed to perform AssertNoError migration", err
-			}
-			changesMade = changes
-			return "", err
-		}))
-	if changesMade {
-		steps = append(steps,
-			step.Cmd(exec.CommandContext(ctx, "gofmt", "-s", "-w", "resources.go")).In(repo.providerDir()),
-			step.Cmd(exec.CommandContext(ctx, "git", "add", "resources.go")).In(&repo.root),
-			step.Cmd(exec.CommandContext(ctx, "git", "commit", "-m", "assertnoerror migration")).In(&repo.root),
-		)
+	metadataPath := fmt.Sprintf("%s/cmd/pulumi-resource-%s/bridge-metadata.json", *repo.providerDir(), providerName)
+	steps = append(steps, step.Cmd(exec.CommandContext(ctx, "git", "add", metadataPath)).In(&repo.root))
+	migrationSteps, err := migrationSteps(ctx, repo, providerName, "Add AutoAliasing", AutoAliasingMigration)
+	if err != nil {
+		return nil, err
 	}
-	return step.Combined("Replace AssertNoError", steps...), nil
+	steps = append(steps, migrationSteps)
+	return step.Combined("Add AutoAliasing", steps...), nil
+}
+
+func ReplaceAssertNoError(ctx Context, repo ProviderRepo, providerName string) (step.Step, error) {
+	return migrationSteps(ctx, repo, providerName, "Remove deprecated contract.Assert",
+		AutoAliasingMigration)
 }

--- a/upgrade/steps.go
+++ b/upgrade/steps.go
@@ -837,6 +837,12 @@ func migrationSteps(ctx Context, repo ProviderRepo, providerName string, descrip
 func AddAutoAliasing(ctx Context, repo ProviderRepo, providerName string) (step.Step, error) {
 	steps := []step.Step{}
 	metadataPath := fmt.Sprintf("%s/cmd/pulumi-resource-%s/bridge-metadata.json", *repo.providerDir(), providerName)
+	if _, err := os.Stat(metadataPath); os.IsNotExist(err) {
+		_, err = os.Create(metadataPath)
+		if err != nil {
+			return nil, err
+		}
+	}
 	steps = append(steps, step.Cmd(exec.CommandContext(ctx, "git", "add", metadataPath)).In(&repo.root))
 	migrationSteps, err := migrationSteps(ctx, repo, providerName, "Add AutoAliasing", AutoAliasingMigration)
 	if err != nil {

--- a/upgrade/upgrade-provider.go
+++ b/upgrade/upgrade-provider.go
@@ -17,7 +17,8 @@ import (
 type CodeMigration = func(ctx Context, repo ProviderRepo, providerName string) (step.Step, error)
 
 var CodeMigrations = map[string]CodeMigration{
-	"autoalias": AddAutoAliasing,
+	"autoalias":     AddAutoAliasing,
+	"assertnoerror": ReplaceAssertNoError,
 }
 
 func UpgradeProvider(ctx Context, name string) error {


### PR DESCRIPTION
Replace `contract.AssertNoError` with `contract.AssertNoErrorf` to fix lint failures, as `AssertNoError` is now deprecated