### PR TITLE
Use current directory if targeted repo

### DIFF
--- a/upgrade/steps-helpers.go
+++ b/upgrade/steps-helpers.go
@@ -324,7 +324,7 @@ func latestRelease(ctx context.Context, repo string) (*semver.Version, error) {
 // getRepoExpectedLocation checks the current working directory to see if `upgrade-provider` is being
 // called from within a provider directory or subdirectory, i.e. `user/home/pulumi/pulumi-docker/provider`.
 // If not, the expected location to clone the repo will be $GOPATH/src/github.com/org.
-func getRepoExpectedLocation(ctx Context, repoPath string) (string, error) {
+func getRepoExpectedLocation(ctx Context, cwd, repoPath string) (string, error) {
 	// Strip version
 	if match := versionSuffix.FindStringIndex(repoPath); match != nil {
 		repoPath = repoPath[:match[0]]
@@ -341,10 +341,6 @@ func getRepoExpectedLocation(ctx Context, repoPath string) (string, error) {
 
 	// from github.com/org/repo to $GOPATH/src/github.com/org
 	expectedLocation := filepath.Join(strings.Split(repoPath, "/")...)
-	cwd, err := os.Getwd()
-	if err != nil {
-		return "", fmt.Errorf("could not resolve current directory: '%s", err)
-	}
 
 	tok := strings.Split(cwd, string(os.PathSeparator))
 	for _, t := range tok {

--- a/upgrade/steps-helpers.go
+++ b/upgrade/steps-helpers.go
@@ -343,9 +343,11 @@ func getRepoExpectedLocation(ctx Context, cwd, repoPath string) (string, error) 
 	expectedLocation := filepath.Join(strings.Split(repoPath, "/")...)
 
 	tok := strings.Split(cwd, string(os.PathSeparator))
+	path := ""
 	for _, t := range tok {
+		path = filepath.Join(path, t)
 		if filepath.Base(expectedLocation) == t && t != "" {
-			return expectedLocation, nil
+			return path, nil
 		}
 	}
 

--- a/upgrade/steps-helpers.go
+++ b/upgrade/steps-helpers.go
@@ -320,3 +320,38 @@ func latestRelease(ctx context.Context, repo string) (*semver.Version, error) {
 
 	return semver.NewVersion(result.Latest.TagName)
 }
+
+// getRepoExpectedLocation checks the current working directory to see if `upgrade-provider` is being
+// called from within a provider directory or subdirectory, i.e. `user/home/pulumi/pulumi-docker/provider`.
+// If not, the expected location to clone the repo will be $GOPATH/src/github.com/org.
+func getRepoExpectedLocation(ctx Context, repoPath string) (string, error) {
+	// Strip version
+	if match := versionSuffix.FindStringIndex(repoPath); match != nil {
+		repoPath = repoPath[:match[0]]
+	}
+
+	if prefix, repo, found := strings.Cut(repoPath, "/terraform-providers/"); found {
+		name := strings.TrimPrefix(repo, "terraform-provider-")
+		org, ok := ProviderOrgs[name]
+		if !ok {
+			return "", fmt.Errorf("terraform-providers based path: missing remap for '%s'", name)
+		}
+		repoPath = prefix + "/" + org + "/" + repo
+	}
+
+	// from github.com/org/repo to $GOPATH/src/github.com/org
+	expectedLocation := filepath.Join(strings.Split(repoPath, "/")...)
+	cwd, err := os.Getwd()
+	if err != nil {
+		return "", fmt.Errorf("could not resolve current directory: '%s", err)
+	}
+
+	tok := strings.Split(cwd, string(os.PathSeparator))
+	for _, t := range tok {
+		if filepath.Base(expectedLocation) == t && t != "" {
+			return expectedLocation, nil
+		}
+	}
+
+	return filepath.Join(ctx.GoPath, "src", expectedLocation), nil
+}

--- a/upgrade/steps-helpers_test.go
+++ b/upgrade/steps-helpers_test.go
@@ -1,0 +1,48 @@
+package upgrade
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetRepoExpectedLocation(t *testing.T) {
+	ctx := Context{
+		GoPath: "Users/myuser/go",
+	}
+
+	cwd, err := os.Getwd()
+	assert.Nil(t, err)
+
+	// test cwd == repo path
+	mockRepoPath := cwd
+	expected, err := getRepoExpectedLocation(ctx, mockRepoPath)
+	mockRepoPath = trimSeparators(mockRepoPath)
+	expected = trimSeparators(expected)
+	assert.Nil(t, err)
+	assert.Equal(t, mockRepoPath, expected)
+
+	// test directory above cwd == repo path
+	mockRepoPath = strings.TrimSuffix(cwd, filepath.Base(cwd))
+	expected, err = getRepoExpectedLocation(ctx, mockRepoPath)
+	assert.Nil(t, err)
+	mockRepoPath = trimSeparators(mockRepoPath)
+	expected = trimSeparators(expected)
+	assert.Equal(t, mockRepoPath, expected)
+
+	// test cwd completely different from repo path
+	mockRepoPath = filepath.Join("github.com", "pulumi", "random-provider")
+	expected, err = getRepoExpectedLocation(ctx, mockRepoPath)
+	expected = trimSeparators(expected)
+	assert.Nil(t, err)
+	assert.Equal(t, filepath.Join(ctx.GoPath, "src", mockRepoPath), expected)
+
+}
+
+func trimSeparators(path string) string {
+	return strings.TrimSuffix(strings.TrimPrefix(path, string(os.PathSeparator)),
+		string(os.PathSeparator))
+}

--- a/upgrade/steps.go
+++ b/upgrade/steps.go
@@ -142,12 +142,10 @@ func ensureUpstreamRepo(ctx Context, repoPath string) step.Step {
 			expectedLocation = filepath.Join(strings.Split(repoPath, "/")...)
 			cwd, err := os.Getwd()
 			if err != nil {
-				return "", fmt.Errorf("could not resolve current directory", err)
+				return "", fmt.Errorf("could not resolve current directory: '%s", err)
 			}
-			fmt.Println("CURRENT WORKING DIRECTORY: ", cwd)
-			fmt.Println(filepath.Base(repoPath))
 			if idx := strings.Index(cwd, filepath.Base(repoPath)); idx != -1 {
-				idx = idx + len(expectedLocation)
+				idx = idx + len(expectedLocation) - 1
 				expectedLocation = cwd[:idx]
 			} else {
 				expectedLocation = filepath.Join(ctx.GoPath, "src", expectedLocation)
@@ -310,7 +308,7 @@ func InformGitHub(
 		panic("Unknown action")
 	}
 	createPR := step.Cmd(exec.CommandContext(ctx, "gh", "pr", "create",
-		"--assignee", "@me",
+		"--add-assignee", "@me",
 		"--base", repo.defaultBranch,
 		"--head", repo.workingBranch,
 		"--reviewer", "pulumi/Ecosystem",

--- a/upgrade/steps.go
+++ b/upgrade/steps.go
@@ -308,7 +308,7 @@ func InformGitHub(
 		panic("Unknown action")
 	}
 	createPR := step.Cmd(exec.CommandContext(ctx, "gh", "pr", "create",
-		"--add-assignee", "@me",
+		"--assignee", "@me",
 		"--base", repo.defaultBranch,
 		"--head", repo.workingBranch,
 		"--reviewer", "pulumi/Ecosystem",

--- a/upgrade/steps.go
+++ b/upgrade/steps.go
@@ -144,6 +144,8 @@ func ensureUpstreamRepo(ctx Context, repoPath string) step.Step {
 			if err != nil {
 				return "", fmt.Errorf("could not resolve current directory", err)
 			}
+			fmt.Println("CURRENT WORKING DIRECTORY: ", cwd)
+			fmt.Println(filepath.Base(repoPath))
 			if idx := strings.Index(cwd, filepath.Base(repoPath)); idx != -1 {
 				idx = idx + len(expectedLocation)
 				expectedLocation = cwd[:idx]

--- a/upgrade/steps.go
+++ b/upgrade/steps.go
@@ -144,7 +144,7 @@ func ensureUpstreamRepo(ctx Context, repoPath string) step.Step {
 			if err != nil {
 				return "", fmt.Errorf("could not resolve current directory", err)
 			}
-			if idx := strings.Index(cwd, expectedLocation); idx != -1 {
+			if idx := strings.Index(cwd, filepath.Base(repoPath)); idx != -1 {
 				idx = idx + len(expectedLocation)
 				expectedLocation = cwd[:idx]
 			} else {

--- a/upgrade/steps.go
+++ b/upgrade/steps.go
@@ -144,12 +144,10 @@ func ensureUpstreamRepo(ctx Context, repoPath string) step.Step {
 			if err != nil {
 				return "", fmt.Errorf("could not resolve current directory: '%s", err)
 			}
-			if idx := strings.Index(cwd, filepath.Base(repoPath)); idx != -1 {
-				idx = idx + len(expectedLocation) - 1
-				expectedLocation = cwd[:idx]
+			if filepath.Base(repoPath) == filepath.Base(cwd) && filepath.Base(cwd) != "" {
+				expectedLocation = cwd
 			} else {
 				expectedLocation = filepath.Join(ctx.GoPath, "src", expectedLocation)
-
 			}
 			if info, err := os.Stat(expectedLocation); err == nil {
 				if !info.IsDir() {

--- a/upgrade/steps.go
+++ b/upgrade/steps.go
@@ -124,8 +124,11 @@ func ensureUpstreamRepo(ctx Context, repoPath string) step.Step {
 	var repoExists bool
 	return step.Combined("Ensure '"+repoPath+"'",
 		step.F("Expected Location", func() (string, error) {
-			var err error
-			expectedLocation, err = getRepoExpectedLocation(ctx, repoPath)
+			cwd, err := os.Getwd()
+			if err != nil {
+				return "", fmt.Errorf("could not resolve cwd: %w", err)
+			}
+			expectedLocation, err = getRepoExpectedLocation(ctx, cwd, repoPath)
 			if err != nil {
 				return "", err
 			}

--- a/upgrade/steps.go
+++ b/upgrade/steps.go
@@ -140,7 +140,17 @@ func ensureUpstreamRepo(ctx Context, repoPath string) step.Step {
 
 			// from github.com/org/repo to $GOPATH/src/github.com/org
 			expectedLocation = filepath.Join(strings.Split(repoPath, "/")...)
-			expectedLocation = filepath.Join(ctx.GoPath, "src", expectedLocation)
+			cwd, err := os.Getwd()
+			if err != nil {
+				return "", fmt.Errorf("could not resolve current directory", err)
+			}
+			if idx := strings.Index(cwd, expectedLocation); idx != -1 {
+				idx = idx + len(expectedLocation)
+				expectedLocation = cwd[:idx]
+			} else {
+				expectedLocation = filepath.Join(ctx.GoPath, "src", expectedLocation)
+
+			}
 			if info, err := os.Stat(expectedLocation); err == nil {
 				if !info.IsDir() {
 					return "", fmt.Errorf("'%s' not a directory", expectedLocation)


### PR DESCRIPTION
Fixes https://github.com/pulumi/upgrade-provider/issues/42
If we run `upgrade-provider pulumi-{provider}` from within `pulumi-{provider}`, we should default to using the current repo instead of cloning