### PR TITLE
Error if target version < current version

### DIFF
--- a/upgrade/upgrade-provider.go
+++ b/upgrade/upgrade-provider.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
+	"golang.org/x/mod/semver"
 
 	"github.com/pulumi/upgrade-provider/colorize"
 	"github.com/pulumi/upgrade-provider/step"
@@ -89,6 +90,11 @@ func UpgradeProvider(ctx Context, name string) error {
 
 				var previous string
 				if repo.currentUpstreamVersion != nil {
+					if semver.Compare(repo.currentUpstreamVersion.String(),
+						upgradeTargets.Latest().String()) > 0 {
+						return "", fmt.Errorf("current upstream version %v is greater than target version %v",
+							repo.currentUpstreamVersion, upgradeTargets.Latest())
+					}
 					previous = fmt.Sprintf("%s -> ", repo.currentUpstreamVersion)
 				}
 


### PR DESCRIPTION
Fixes #63 

If a target upgrade version is less than the current version, the update should error.