### PR TITLE
Accept {org/repo} as argument to upgrade-provider

### DIFF
--- a/main.go
+++ b/main.go
@@ -59,6 +59,11 @@ func cmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
+			// Require `upstream-provider-name` to be set
+			if context.UpstreamProviderName == "" {
+				return errors.New("`upstream-provider-name` must be provided")
+			}
+
 			// Validate that maxVersion is a valid version
 			if maxVersion != "" {
 				context.MaxVersion, err = semver.NewVersion(maxVersion)

--- a/main.go
+++ b/main.go
@@ -153,8 +153,7 @@ If the passed version does not exist, an error is signaled.`)
 - "autoalias": Apply auto aliasing to the provider.`)
 
 	cmd.PersistentFlags().StringVar(&context.UpstreamProviderName, "upstream-provider-name", "",
-		`The name of the upstream provider.
-Must be set in '.upgrade-config.yml' or passed with flag.`)
+		`The name of the upstream provider.`)
 
 	return cmd
 }

--- a/main.go
+++ b/main.go
@@ -146,7 +146,8 @@ If the passed version does not exist, an error is signaled.`)
 - "autoalias": Apply auto aliasing to the provider.`)
 
 	cmd.PersistentFlags().StringVar(&context.UpstreamProviderName, "upstream-provider-name", "",
-		"The name of the upstream provider.")
+		`The name of the upstream provider.
+Must be set in '.upgrade-config.yml' or passed with flag.`)
 
 	return cmd
 }

--- a/main.go
+++ b/main.go
@@ -64,8 +64,7 @@ func cmd() *cobra.Command {
 			// Validate argument is {org}/{repo}
 			tok := strings.Split(args[0], "/")
 			if len(tok) != 2 {
-				fmt.Println("error: argument must be provided as {org}/{repo}")
-				os.Exit(1)
+				return errors.New("argument must be provided as {org}/{repo}")
 			}
 			repoOrg, repoName = tok[0], tok[1]
 			// Require `upstream-provider-name` to be set

--- a/main.go
+++ b/main.go
@@ -67,6 +67,10 @@ func cmd() *cobra.Command {
 				return errors.New("argument must be provided as {org}/{repo}")
 			}
 			repoOrg, repoName = tok[0], tok[1]
+			// repo name should start with 'pulumi-'
+			if !strings.HasPrefix(repoName, "pulumi-") {
+				return errors.New("{repo} must start with `pulumi-`")
+			}
 			// Require `upstream-provider-name` to be set
 			if context.UpstreamProviderName == "" {
 				return errors.New("`upstream-provider-name` must be provided")

--- a/main.go
+++ b/main.go
@@ -112,7 +112,13 @@ func cmd() *cobra.Command {
 			return nil
 		},
 		Run: func(_ *cobra.Command, args []string) {
-			err := upgrade.UpgradeProvider(context, args[0])
+			// Validate argument is {org}/{repo}
+			tok := strings.Split(args[0], "/")
+			if len(tok) != 2 {
+				fmt.Println("error: argument must be provided as {org}/{repo}")
+				os.Exit(1)
+			}
+			err := upgrade.UpgradeProvider(context, tok[0], tok[1])
 			exitOnError(err)
 		},
 	}

--- a/upgrade/steps.go
+++ b/upgrade/steps.go
@@ -497,7 +497,7 @@ func GetExpectedTarget(ctx Context, name string) ([]UpgradeTargetIssue, string, 
 	getIssues := exec.CommandContext(ctx, "gh", "issue", "list",
 		"--state=open",
 		"--author=pulumi-bot",
-		"--repo=pulumi/"+name,
+		"--repo="+name,
 		"--limit=100",
 		"--json=title,number")
 	bytes := new(bytes.Buffer)
@@ -556,8 +556,8 @@ func GetExpectedTarget(ctx Context, name string) ([]UpgradeTargetIssue, string, 
 	return versions, "", nil
 }
 
-func PulumiProviderRepos(ctx Context, name string) step.Step {
-	return ensureUpstreamRepo(ctx, path.Join("github.com", "pulumi", name))
+func OrgProviderRepos(ctx Context, name string) step.Step {
+	return ensureUpstreamRepo(ctx, path.Join("github.com", name))
 }
 
 func PullDefaultBranch(ctx Context, remote string) step.Step {
@@ -845,8 +845,8 @@ func migrationSteps(ctx Context, repo ProviderRepo, providerName string, descrip
 	return steps, nil
 }
 
-func AddAutoAliasing(ctx Context, repo ProviderRepo, providerName string) (step.Step, error) {
-	providerName = strings.TrimPrefix(providerName, "pulumi-")
+func AddAutoAliasing(ctx Context, repo ProviderRepo) (step.Step, error) {
+	providerName := strings.TrimPrefix(repo.name, "pulumi-")
 	metadataPath := fmt.Sprintf("%s/cmd/pulumi-resource-%s/bridge-metadata.json", *repo.providerDir(), providerName)
 	steps := []step.Step{
 		step.F("ensure bridge-metadata.json", func() (string, error) {
@@ -870,8 +870,8 @@ func AddAutoAliasing(ctx Context, repo ProviderRepo, providerName string) (step.
 	return step.Combined("Add AutoAliasing", steps...), nil
 }
 
-func ReplaceAssertNoError(ctx Context, repo ProviderRepo, providerName string) (step.Step, error) {
-	steps, err := migrationSteps(ctx, repo, providerName, "Remove deprecated contract.Assert",
+func ReplaceAssertNoError(ctx Context, repo ProviderRepo) (step.Step, error) {
+	steps, err := migrationSteps(ctx, repo, repo.name, "Remove deprecated contract.Assert",
 		AssertNoErrorMigration)
 	if err != nil {
 		return nil, err

--- a/upgrade/steps.go
+++ b/upgrade/steps.go
@@ -294,7 +294,7 @@ func InformGitHub(
 
 	var prTitle string
 	if ctx.UpgradeProviderVersion {
-		prTitle = fmt.Sprintf("Upgrade terraform-provider-%s to v%s",
+		prTitle = fmt.Sprintf("Upgrade %s to v%s",
 			ctx.UpstreamProviderName, target.Latest())
 	} else if ctx.UpgradeBridgeVersion {
 		prTitle = "Upgrade pulumi-terraform-bridge to " + targetBridgeVersion
@@ -556,8 +556,8 @@ func GetExpectedTarget(ctx Context, name string) ([]UpgradeTargetIssue, string, 
 	return versions, "", nil
 }
 
-func OrgProviderRepos(ctx Context, name string) step.Step {
-	return ensureUpstreamRepo(ctx, path.Join("github.com", name))
+func OrgProviderRepos(ctx Context, org, repo string) step.Step {
+	return ensureUpstreamRepo(ctx, path.Join("github.com", org, repo))
 }
 
 func PullDefaultBranch(ctx Context, remote string) step.Step {

--- a/upgrade/upgrade-provider.go
+++ b/upgrade/upgrade-provider.go
@@ -59,7 +59,7 @@ func UpgradeProvider(ctx Context, repoOrg, repoName string) error {
 				var msg string
 				upgradeTargets, msg, err = GetExpectedTarget(ctx, repoOrg+"/"+repoName)
 				if err != nil {
-					return "failed to get expected upgrade version", err
+					return "", err
 				}
 
 				// If we have upgrades to perform, we list the new version we will target

--- a/upgrade/util.go
+++ b/upgrade/util.go
@@ -49,6 +49,9 @@ type ProviderRepo struct {
 	// The upstream version we are upgrading from.  Because not all upstream providers
 	// are go module compliment, we might not be able to always resolve this version.
 	currentUpstreamVersion *semver.Version
+
+	name string
+	org  string
 }
 
 func (p ProviderRepo) providerDir() *string {


### PR DESCRIPTION
Fixes #65 
Instead of assuming the target repo is part of the pulumi github org, we require the org/repo name to be passed in 