### PR TITLE
Allow target upstream version to be passed in

### DIFF
--- a/main.go
+++ b/main.go
@@ -161,7 +161,7 @@ If the passed version does not exist, an error is signaled.`)
 		`The kind of upgrade to perform:
 - "all":     Upgrade the upstream provider and the bridge. Shorthand for "bridge,provider,code".
 - "bridge":  Upgrade the bridge only.
-- "provider: Upgrade the upstre am provider only.
+- "provider: Upgrade the upstream provider only.
 - "code":     Perform some number of code migrations.`)
 
 	cmd.PersistentFlags().BoolVar(&experimental, "experimental", false,

--- a/main.go
+++ b/main.go
@@ -144,7 +144,8 @@ If the passed version does not exist, an error is signaled.`)
 		`Use our GH issues to infer the target upgrade version.
 		If both '--target-version' and '--pulumi-infer-version' are passed,
 		we take '--target-version' to cap the inferred version. [Hidden behind PULUMI_DEV]`)
-	cmd.PersistentFlags().MarkHidden("pulumi-infer-version")
+	err := cmd.PersistentFlags().MarkHidden("pulumi-infer-version")
+	contract.AssertNoErrorf(err, "error: %w", err)
 
 	cmd.PersistentFlags().BoolVar(&context.MajorVersionBump, "major", false,
 		`Upgrade the provider to a new major version.`)

--- a/main.go
+++ b/main.go
@@ -144,6 +144,7 @@ If the passed version does not exist, an error is signaled.`)
 		`Use our GH issues to infer the target upgrade version.
 		If both '--target-version' and '--pulumi-infer-version' are passed,
 		we take '--target-version' to cap the inferred version. [Hidden behind PULUMI_DEV]`)
+	cmd.PersistentFlags().MarkHidden("pulumi-infer-version")
 
 	cmd.PersistentFlags().BoolVar(&context.MajorVersionBump, "major", false,
 		`Upgrade the provider to a new major version.`)

--- a/main.go
+++ b/main.go
@@ -27,7 +27,7 @@ const (
 )
 
 func cmd() *cobra.Command {
-	var maxVersion string
+	var inferVersion bool
 	var targetVersion string
 	gopath, ok := os.LookupEnv("GOPATH")
 	if !ok {
@@ -86,15 +86,6 @@ func cmd() *cobra.Command {
 				}
 			}
 
-			// Validate that maxVersion is a valid version
-			if maxVersion != "" {
-				context.MaxVersion, err = semver.NewVersion(maxVersion)
-				if err != nil {
-					return fmt.Errorf("--provider-version=%s: %w",
-						maxVersion, err)
-				}
-			}
-
 			// Validate the kind switch
 			var warnedAll bool
 			for _, kind := range upgradeKind {
@@ -132,7 +123,7 @@ func cmd() *cobra.Command {
 				}
 			}
 
-			if context.MaxVersion != nil && !context.UpgradeProviderVersion {
+			if context.TargetVersion != nil && !context.UpgradeProviderVersion {
 				return fmt.Errorf(
 					"cannot specify the provider version unless the provider will be upgraded")
 			}
@@ -149,10 +140,10 @@ func cmd() *cobra.Command {
 
 If the passed version does not exist, an error is signaled.`)
 
-	cmd.PersistentFlags().StringVar(&maxVersion, "max-version", "",
-		`Limit the provider upgrade to the passed version when the target version is not provided.
-
-If the passed version does not exist, an error is signaled.`)
+	cmd.PersistentFlags().BoolVar(&inferVersion, "pulumi-infer-version", false,
+		`Use our GH issues to infer the target upgrade version.
+		If both '--target-version' and '--pulumi-infer-version' are passed,
+		we take '--target-version' to cap the inferred version. [Hidden behind PULUMI_DEV]`)
 
 	cmd.PersistentFlags().BoolVar(&context.MajorVersionBump, "major", false,
 		`Upgrade the provider to a new major version.`)

--- a/main.go
+++ b/main.go
@@ -145,7 +145,7 @@ If the passed version does not exist, an error is signaled.`)
 		If both '--target-version' and '--pulumi-infer-version' are passed,
 		we take '--target-version' to cap the inferred version. [Hidden behind PULUMI_DEV]`)
 	err := cmd.PersistentFlags().MarkHidden("pulumi-infer-version")
-	contract.AssertNoErrorf(err, "error: %w", err)
+	contract.AssertNoErrorf(err, "could not mark `pulumi-infer-version` flag as hidden")
 
 	cmd.PersistentFlags().BoolVar(&context.MajorVersionBump, "major", false,
 		`Upgrade the provider to a new major version.`)

--- a/upgrade/steps-helpers.go
+++ b/upgrade/steps-helpers.go
@@ -110,7 +110,9 @@ func prBody(ctx Context, repo ProviderRepo, upgradeTargets UpstreamVersions, goM
 		fmt.Fprintf(b, "\n")
 	}
 	for _, t := range upgradeTargets {
-		fmt.Fprintf(b, "Fixes #%d\n", t.Number)
+		if t.Number > 0 {
+			fmt.Fprintf(b, "Fixes #%d\n", t.Number)
+		}
 	}
 	return b.String()
 }

--- a/upgrade/steps-helpers.go
+++ b/upgrade/steps-helpers.go
@@ -82,7 +82,7 @@ func originalGoVersionOf(ctx context.Context, repo ProviderRepo, file, needleMod
 	return module.Version{}, false, nil
 }
 
-func prBody(ctx Context, repo ProviderRepo, upgradeTargets UpstreamVersions, goMod *GoMod, targetBridge string) string {
+func prBody(ctx Context, repo ProviderRepo, upgradeTarget *UpstreamUpgradeTarget, goMod *GoMod, targetBridge string) string {
 	b := new(strings.Builder)
 	fmt.Fprintf(b, "This PR was generated via `$ upgrade-provider %s`.\n",
 		strings.Join(os.Args[1:], " "))
@@ -99,17 +99,17 @@ func prBody(ctx Context, repo ProviderRepo, upgradeTargets UpstreamVersions, goM
 			prev = fmt.Sprintf("from %s ", repo.currentUpstreamVersion)
 		}
 		fmt.Fprintf(b, "Upgrading %s %s to %s.\n",
-			ctx.UpstreamProviderName, prev, upgradeTargets.Latest())
+			ctx.UpstreamProviderName, prev, upgradeTarget.Version)
 	}
 	if ctx.UpgradeBridgeVersion {
 		fmt.Fprintf(b, "Upgrading pulumi-terraform-bridge from %s to %s.\n",
 			goMod.Bridge.Version, targetBridge)
 	}
 
-	if len(upgradeTargets) > 0 {
+	if len(upgradeTarget.GHIssues) > 0 {
 		fmt.Fprintf(b, "\n")
 	}
-	for _, t := range upgradeTargets {
+	for _, t := range upgradeTarget.GHIssues {
 		if t.Number > 0 {
 			fmt.Fprintf(b, "Fixes #%d\n", t.Number)
 		}

--- a/upgrade/steps-helpers.go
+++ b/upgrade/steps-helpers.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 
 	"github.com/Masterminds/semver/v3"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 	"golang.org/x/mod/modfile"
 	"golang.org/x/mod/module"
 )
@@ -94,12 +95,18 @@ func prBody(ctx Context, repo ProviderRepo, upgradeTarget *UpstreamUpgradeTarget
 	}
 
 	if ctx.UpgradeProviderVersion {
+		contract.Assertf(upgradeTarget != nil, "upgradeTarget should always be non-nil")
 		var prev string
 		if repo.currentUpstreamVersion != nil {
 			prev = fmt.Sprintf("from %s ", repo.currentUpstreamVersion)
 		}
 		fmt.Fprintf(b, "Upgrading %s %s to %s.\n",
 			ctx.UpstreamProviderName, prev, upgradeTarget.Version)
+		for _, t := range upgradeTarget.GHIssues {
+			if t.Number > 0 {
+				fmt.Fprintf(b, "Fixes #%d\n", t.Number)
+			}
+		}
 	}
 	if ctx.UpgradeBridgeVersion {
 		fmt.Fprintf(b, "Upgrading pulumi-terraform-bridge from %s to %s.\n",
@@ -109,11 +116,7 @@ func prBody(ctx Context, repo ProviderRepo, upgradeTarget *UpstreamUpgradeTarget
 	if len(upgradeTarget.GHIssues) > 0 {
 		fmt.Fprintf(b, "\n")
 	}
-	for _, t := range upgradeTarget.GHIssues {
-		if t.Number > 0 {
-			fmt.Fprintf(b, "Fixes #%d\n", t.Number)
-		}
-	}
+
 	return b.String()
 }
 

--- a/upgrade/steps.go
+++ b/upgrade/steps.go
@@ -664,7 +664,7 @@ func MajorVersionBump(ctx Context, goMod *GoMod, target *UpstreamUpgradeTarget, 
 					if idx := versionSuffix.FindStringIndex(goMod.Upstream.Path); idx != nil {
 						newUpstream := fmt.Sprintf("%s/v%d",
 							goMod.Upstream.Path[:idx[0]],
-							target.Version,
+							target.Version.Major(),
 						)
 						new = bytes.ReplaceAll(data,
 							[]byte(goMod.Upstream.Path),

--- a/upgrade/steps.go
+++ b/upgrade/steps.go
@@ -532,7 +532,7 @@ func GetExpectedTarget(ctx Context, name string) ([]UpgradeTargetIssue, string, 
 		}
 		v, err := semver.NewVersion(version)
 		if err == nil {
-			if !(ctx.MaxVersion == nil || ctx.MaxVersion.Equal(v) || ctx.MaxVersion.GreaterThan(v)) {
+			if ctx.InferVersion && !(ctx.TargetVersion == nil || ctx.TargetVersion.Equal(v) || ctx.TargetVersion.GreaterThan(v)) {
 				versionConstrained = true
 				continue
 			}
@@ -544,7 +544,7 @@ func GetExpectedTarget(ctx Context, name string) ([]UpgradeTargetIssue, string, 
 	}
 	if len(versions) == 0 {
 		var extra string
-		if versionConstrained {
+		if ctx.InferVersion && versionConstrained {
 			extra = " (a version was found but it was greater then the specified max)"
 		}
 		return nil, extra, nil
@@ -553,8 +553,8 @@ func GetExpectedTarget(ctx Context, name string) ([]UpgradeTargetIssue, string, 
 		return versions[j].Version.LessThan(versions[i].Version)
 	})
 
-	if ctx.MaxVersion != nil && !versions[0].Version.Equal(ctx.MaxVersion) {
-		return nil, "", fmt.Errorf("possible upgrades exist, but non match %s", ctx.MaxVersion)
+	if ctx.InferVersion && ctx.TargetVersion != nil && !versions[0].Version.Equal(ctx.TargetVersion) {
+		return nil, "", fmt.Errorf("possible upgrades exist, but non match %s", ctx.TargetVersion)
 	}
 
 	return versions, "", nil

--- a/upgrade/steps.go
+++ b/upgrade/steps.go
@@ -520,7 +520,7 @@ func GetExpectedTarget(ctx Context, name string) (*UpstreamUpgradeTarget, string
 		return nil, "", err
 	}
 
-	var versions UpstreamVersions
+	var versions []UpgradeTargetIssue
 	var versionConstrained bool
 	for _, title := range titles {
 		_, nameToVersion, found := strings.Cut(title.Title, "Upgrade terraform-provider-")
@@ -559,7 +559,7 @@ func GetExpectedTarget(ctx Context, name string) (*UpstreamUpgradeTarget, string
 	}
 
 	target.GHIssues = versions
-	target.Version = versions.Latest()
+	target.Version = versions[0].Version
 	return target, "", nil
 }
 

--- a/upgrade/steps.go
+++ b/upgrade/steps.go
@@ -496,7 +496,6 @@ func EnsureBranchCheckedOut(ctx Context, branchName string) step.Step {
 func GetExpectedTarget(ctx Context, name string) (*UpstreamUpgradeTarget, string, error) {
 	target := &UpstreamUpgradeTarget{Version: ctx.TargetVersion}
 	if ctx.TargetVersion != nil {
-		target.Version = ctx.TargetVersion
 		return target, "", nil
 	}
 

--- a/upgrade/steps.go
+++ b/upgrade/steps.go
@@ -494,6 +494,10 @@ func EnsureBranchCheckedOut(ctx Context, branchName string) step.Step {
 //
 // The second argument represents a message to describe the result. It may be empty.
 func GetExpectedTarget(ctx Context, name string) ([]UpgradeTargetIssue, string, error) {
+	if ctx.TargetVersion != nil {
+		return []UpgradeTargetIssue{{Version: ctx.TargetVersion, Number: 0}}, "", nil
+	}
+
 	getIssues := exec.CommandContext(ctx, "gh", "issue", "list",
 		"--state=open",
 		"--author=pulumi-bot",

--- a/upgrade/upgrade-provider.go
+++ b/upgrade/upgrade-provider.go
@@ -64,6 +64,7 @@ func UpgradeProvider(ctx Context, repoOrg, repoName string) error {
 				}
 
 				// If we have upgrades to perform, we list the new version we will target
+				// unless a version was passed in via `--provider-version`
 				if len(upgradeTargets) == 0 {
 					// Otherwise, we don't bother to try to upgrade the provider.
 					ctx.UpgradeProviderVersion = false

--- a/upgrade/upgrade-provider.go
+++ b/upgrade/upgrade-provider.go
@@ -192,7 +192,7 @@ func UpgradeProvider(ctx Context, repoOrg, repoName string) error {
 	}
 
 	if ctx.MajorVersionBump {
-		steps = append(steps, MajorVersionBump(ctx, goMod, upgradeTarget.GHIssues, repo))
+		steps = append(steps, MajorVersionBump(ctx, goMod, upgradeTarget, repo))
 
 		defer func() {
 			fmt.Printf("\n\n" + colorize.Warn("Major Version Updates are not fully automated!") + "\n")
@@ -281,7 +281,7 @@ func UpgradeProvider(ctx Context, repoOrg, repoName string) error {
 		}),
 		step.Cmd(exec.CommandContext(ctx, "git", "add", "--all")).In(&repo.root),
 		GitCommit(ctx, "make build_sdks").In(&repo.root),
-		InformGitHub(ctx, upgradeTarget.GHIssues, repo, goMod, targetBridgeVersion),
+		InformGitHub(ctx, upgradeTarget, repo, goMod, targetBridgeVersion),
 	)
 
 	ok = step.Run(step.Combined("Update Artifacts", artifacts...))

--- a/upgrade/util.go
+++ b/upgrade/util.go
@@ -14,7 +14,8 @@ type Context struct {
 
 	GoPath string
 
-	MaxVersion *semver.Version
+	TargetVersion *semver.Version
+	MaxVersion    *semver.Version
 
 	UpgradeBridgeVersion bool
 

--- a/upgrade/util.go
+++ b/upgrade/util.go
@@ -72,6 +72,13 @@ type GoMod struct {
 	Bridge   module.Version
 }
 
+type UpstreamUpgradeTarget struct {
+	// The version we are targeting. `nil` indicates that no upstream upgrade was found.
+	Version *semver.Version
+	// The list of issues that this upgrade will close.
+	GHIssues []UpgradeTargetIssue
+}
+
 type UpgradeTargetIssue struct {
 	Version *semver.Version `json:"-"`
 	Number  int             `json:"number"`

--- a/upgrade/util.go
+++ b/upgrade/util.go
@@ -83,10 +83,3 @@ type UpgradeTargetIssue struct {
 	Version *semver.Version `json:"-"`
 	Number  int             `json:"number"`
 }
-
-// The sorted list of upstream versions that will be fixed with this update.
-type UpstreamVersions []UpgradeTargetIssue
-
-func (p UpstreamVersions) Latest() *semver.Version {
-	return p[0].Version
-}

--- a/upgrade/util.go
+++ b/upgrade/util.go
@@ -15,7 +15,7 @@ type Context struct {
 	GoPath string
 
 	TargetVersion *semver.Version
-	MaxVersion    *semver.Version
+	InferVersion  bool
 
 	UpgradeBridgeVersion bool
 


### PR DESCRIPTION
Provide a flag `--target-version` to specify the upstream version to upgrade to