### PR TITLE
Add option to only upgrade `pu/sdk` + `pu/pkg`

### DIFF
--- a/main.go
+++ b/main.go
@@ -102,6 +102,7 @@ func cmd() *cobra.Command {
 				case "all":
 					context.UpgradeBridgeVersion = true
 					context.UpgradeProviderVersion = true
+					context.UpgradeSdkVersion = true
 					if experimental {
 						context.UpgradeCodeMigration = true
 					}
@@ -115,6 +116,8 @@ func cmd() *cobra.Command {
 					set(&context.UpgradeProviderVersion)
 				case "code":
 					set(&context.UpgradeCodeMigration)
+				case "sdk":
+					set(&context.UpgradeSdkVersion)
 				default:
 					return fmt.Errorf(
 						"--kind=%s invalid. Must be one of `all`, `bridge`, `provider`, or `code`.",
@@ -146,7 +149,8 @@ If the passed version does not exist, an error is signaled.`)
 		`The kind of upgrade to perform:
 - "all":     Upgrade the upstream provider and the bridge. Shorthand for "bridge,provider,code".
 - "bridge":  Upgrade the bridge only.
-- "provider: Upgrade the upstream provider only.
+- "provider": Upgrade the upstream provider only.
+- "sdk": Upgrade the Pulumi sdk only.
 - "code":     Perform some number of code migrations.`)
 
 	cmd.PersistentFlags().BoolVar(&experimental, "experimental", false,

--- a/upgrade/upgrade-provider.go
+++ b/upgrade/upgrade-provider.go
@@ -220,6 +220,15 @@ func UpgradeProvider(ctx Context, repoOrg, repoName string) error {
 			"go", "get", "github.com/pulumi/pulumi-terraform-bridge/v3@"+targetBridgeVersion)).
 			In(repo.providerDir()))
 	}
+	if ctx.UpgradeSdkVersion {
+		steps = append(steps,
+			step.Cmd(exec.CommandContext(ctx,
+				"go", "get", "github.com/pulumi/pulumi/sdk/v3")).
+				In(repo.providerDir()),
+			step.Cmd(exec.CommandContext(ctx,
+				"go", "get", "github.com/pulumi/pulumi/pkg/v3")).
+				In(repo.providerDir()))
+	}
 
 	if ctx.UpgradeCodeMigration {
 		applied := make(map[string]struct{})

--- a/upgrade/upgrade-provider.go
+++ b/upgrade/upgrade-provider.go
@@ -149,7 +149,8 @@ func UpgradeProvider(ctx Context, repoOrg, repoName string) error {
 
 	// Running the discover steps might have invalidated one or more actions. If there
 	// are no actions remaining, we can exit early.
-	if !ctx.UpgradeBridgeVersion && !ctx.UpgradeProviderVersion && !ctx.UpgradeCodeMigration {
+	if !ctx.UpgradeBridgeVersion && !ctx.UpgradeProviderVersion &&
+		!ctx.UpgradeCodeMigration && ctx.UpgradeSdkVersion {
 		fmt.Println(colorize.Bold("No actions needed"))
 		return nil
 	}
@@ -227,7 +228,7 @@ func UpgradeProvider(ctx Context, repoOrg, repoName string) error {
 				In(repo.providerDir()),
 			step.Cmd(exec.CommandContext(ctx,
 				"go", "get", "github.com/pulumi/pulumi/pkg/v3")).
-				In(repo.providerDir()))
+				In(repo.providerDir())))
 	}
 
 	if ctx.UpgradeCodeMigration {

--- a/upgrade/upgrade-provider.go
+++ b/upgrade/upgrade-provider.go
@@ -221,7 +221,7 @@ func UpgradeProvider(ctx Context, repoOrg, repoName string) error {
 			In(repo.providerDir()))
 	}
 	if ctx.UpgradeSdkVersion {
-		steps = append(steps,
+		steps = append(steps, step.Combined("Upgrade Pulumi SDK",
 			step.Cmd(exec.CommandContext(ctx,
 				"go", "get", "github.com/pulumi/pulumi/sdk/v3")).
 				In(repo.providerDir()),

--- a/upgrade/util.go
+++ b/upgrade/util.go
@@ -17,6 +17,7 @@ type Context struct {
 	MaxVersion *semver.Version
 
 	UpgradeBridgeVersion bool
+	UpgradeSdkVersion    bool
 
 	UpgradeProviderVersion bool
 	MajorVersionBump       bool


### PR DESCRIPTION
We should have an option to update only `pu/sdk` and `pu/pu`. This will make it easier to review PR changes and allow us to keep providers up to date more often