### PR TITLE
List upgrade steps in pr body as bullet points

### DIFF
--- a/upgrade/steps-helpers.go
+++ b/upgrade/steps-helpers.go
@@ -91,7 +91,7 @@ func prBody(ctx Context, repo ProviderRepo, upgradeTarget *UpstreamUpgradeTarget
 	fmt.Fprintf(b, "\n---\n\n")
 
 	if ctx.MajorVersionBump {
-		fmt.Fprintf(b, "Updating major version from %s to %s.\n", repo.currentVersion, repo.currentVersion.IncMajor())
+		fmt.Fprintf(b, "- Updating major version from %s to %s.\n", repo.currentVersion, repo.currentVersion.IncMajor())
 	}
 
 	if ctx.UpgradeProviderVersion {
@@ -100,7 +100,7 @@ func prBody(ctx Context, repo ProviderRepo, upgradeTarget *UpstreamUpgradeTarget
 		if repo.currentUpstreamVersion != nil {
 			prev = fmt.Sprintf("from %s ", repo.currentUpstreamVersion)
 		}
-		fmt.Fprintf(b, "Upgrading %s %s to %s.\n",
+		fmt.Fprintf(b, "- Upgrading %s %s to %s.\n",
 			ctx.UpstreamProviderName, prev, upgradeTarget.Version)
 		for _, t := range upgradeTarget.GHIssues {
 			if t.Number > 0 {
@@ -109,7 +109,7 @@ func prBody(ctx Context, repo ProviderRepo, upgradeTarget *UpstreamUpgradeTarget
 		}
 	}
 	if ctx.UpgradeBridgeVersion {
-		fmt.Fprintf(b, "Upgrading pulumi-terraform-bridge from %s to %s.\n",
+		fmt.Fprintf(b, "- Upgrading pulumi-terraform-bridge from %s to %s.\n",
 			goMod.Bridge.Version, targetBridge)
 	}
 

--- a/upgrade/upgrade-provider.go
+++ b/upgrade/upgrade-provider.go
@@ -176,7 +176,7 @@ func UpgradeProvider(ctx Context, repoOrg, repoName string) error {
 
 	var targetSHA string
 	if ctx.UpgradeProviderVersion {
-		repo.workingBranch = fmt.Sprintf("upgrade-terraform-provider-%s-to-v%s",
+		repo.workingBranch = fmt.Sprintf("upgrade-%s-to-v%s",
 			ctx.UpstreamProviderName, upgradeTarget.Version)
 	} else if ctx.UpgradeBridgeVersion {
 		contract.Assertf(targetBridgeVersion != "",


### PR DESCRIPTION
- [16539cc](https://github.com/pulumi/upgrade-provider/pull/78/commits/16539cc333f9ab081e6a069cc6b653be68a440dd) improves the PR body readability
- [b1f2e01](https://github.com/pulumi/upgrade-provider/pull/78/commits/b1f2e01f35b7da0c604b62d1ef9279a81c9bddd1) fixes the branch name that we checkout (such as https://github.com/pulumi/pulumi-newrelic/pull/436)

