### PR TITLE
Fix empty repo path handling

### DIFF
--- a/upgrade/steps-helpers.go
+++ b/upgrade/steps-helpers.go
@@ -20,11 +20,6 @@ import (
 
 var versionSuffix = regexp.MustCompile("/v[2-9][0-9]*$")
 
-func downloadRepo(ctx Context, url, dst string) error {
-	cmd := exec.CommandContext(ctx, "git", "clone", url, dst)
-	return cmd.Run()
-}
-
 func runGitCommand[T any](
 	ctx context.Context, filter func([]byte) (T, error), args ...string,
 ) (result T, err error) {
@@ -323,8 +318,8 @@ func latestRelease(ctx context.Context, repo string) (*semver.Version, error) {
 // 3) default: $GOPATH/src/module, i.e. $GOPATH/src/github.com/pulumi/pulumi-datadog
 func getRepoExpectedLocation(ctx Context, cwd, repoPath string) (string, error) {
 	// We assume the user passed in a valid path, either absolute or relative.
-	if ctx.repoPath != nil {
-		return *ctx.repoPath, nil
+	if ctx.repoPath != "" {
+		return ctx.repoPath, nil
 	}
 
 	// Strip version

--- a/upgrade/util.go
+++ b/upgrade/util.go
@@ -15,7 +15,7 @@ type Context struct {
 	// The user's GOPATH env var
 	GoPath string
 	// An optional path to clone the provider repo to
-	repoPath *string
+	repoPath string
 
 	TargetVersion *semver.Version
 	InferVersion  bool
@@ -34,8 +34,8 @@ type Context struct {
 	RemovePlugins bool
 }
 
-func (c Context) SetRepoPath(p string) {
-	*c.repoPath = p
+func (c *Context) SetRepoPath(p string) {
+	c.repoPath = p
 }
 
 type HandledError struct{}


### PR DESCRIPTION
Fixes a bug introduced by https://github.com/pulumi/upgrade-provider/pull/83.

Prior to this PR, `context.SetRepoPath(repoPath)` was called unconditionally but `repoPath` often had a value of `""`. This mean that failing to specify repo path would always result in failure.