### PR TITLE
Create issue on upgrade provider failure

### DIFF
--- a/main.go
+++ b/main.go
@@ -274,8 +274,8 @@ func createFailureIssue(ctx upgrade.Context, repoOrg string, repoName string) (s
 		"--limit=1",
 		"--json=url",
 	)
-	bytes1 := new(bytes.Buffer)
-	getLatestWorkflowRun.Stdout = bytes1
+	ghRunBytes := new(bytes.Buffer)
+	getLatestWorkflowRun.Stdout = ghRunBytes
 	err := getLatestWorkflowRun.Run()
 	if err != nil {
 		return "createFailureIssue error: failed to query latest workflow run", err
@@ -283,7 +283,7 @@ func createFailureIssue(ctx upgrade.Context, repoOrg string, repoName string) (s
 	var workflowRunUrls []struct {
 		Url string `json:"url"`
 	}
-	err = json.Unmarshal(bytes1.Bytes(), &workflowRunUrls)
+	err = json.Unmarshal(ghRunBytes.Bytes(), &workflowRunUrls)
 	if err != nil {
 		return "createFailureIssue error: failed to unmarshal `gh run list` output", err
 	}
@@ -299,7 +299,8 @@ func createFailureIssue(ctx upgrade.Context, repoOrg string, repoName string) (s
 		"--state=open",
 		"--author=pulumi-bot",
 	)
-	getIssues.Stdout = new(bytes.Buffer)
+	ghSearchBytes := new(bytes.Buffer)
+	getIssues.Stdout = ghSearchBytes
 	err = getIssues.Run()
 	if err != nil {
 		return "createFailureIssue error: failed to search existing issues", err
@@ -308,7 +309,7 @@ func createFailureIssue(ctx upgrade.Context, repoOrg string, repoName string) (s
 		Title  string `json:"title"`
 		Number int    `json:"number"`
 	}{}
-	err = json.Unmarshal(getIssues.Stdout.Bytes(), &titles)
+	err = json.Unmarshal(ghSearchBytes.Bytes(), &titles)
 	if err != nil {
 		return "createFailureIssue error: failed to unmarshal `gh search issues` output", err
 	}

--- a/main.go
+++ b/main.go
@@ -142,7 +142,7 @@ func cmd() *cobra.Command {
 			err := upgrade.UpgradeProvider(context, repoOrg, repoName)
 			if err != nil {
 				msg, err := createFailureIssue(context, repoOrg, repoName)
-				if err != nil {
+				if err != nil && context.InferVersion {
 					fmt.Println(msg)
 				}
 			}

--- a/main.go
+++ b/main.go
@@ -140,9 +140,9 @@ func cmd() *cobra.Command {
 		},
 		Run: func(_ *cobra.Command, args []string) {
 			err := upgrade.UpgradeProvider(context, repoOrg, repoName)
-			if err != nil {
+			if err != nil && context.InferVersion {
 				msg, err := createFailureIssue(context, repoOrg, repoName)
-				if err != nil && context.InferVersion {
+				if err != nil {
 					fmt.Println(msg)
 				}
 			}

--- a/main.go
+++ b/main.go
@@ -280,9 +280,9 @@ func createFailureIssue(ctx upgrade.Context, repoOrg string, repoName string) (s
 	if err != nil {
 		return "createFailureIssue error: failed to query latest workflow run", err
 	}
-	workflowRunUrls := []struct {
+	var workflowRunUrls []struct {
 		Url string `json:"url"`
-	}{}
+	}
 	err = json.Unmarshal(bytes1.Bytes(), &workflowRunUrls)
 	if err != nil {
 		return "createFailureIssue error: failed to unmarshal `gh run list` output", err
@@ -296,9 +296,9 @@ func createFailureIssue(ctx upgrade.Context, repoOrg string, repoName string) (s
 		"Upgrade provider failure: ",
 		"--repo="+repoOrg+"/"+repoName,
 		"--json=title,number",
+		"--state=open",
 	)
-	bytes2 := new(bytes.Buffer)
-	getIssues.Stdout = bytes2
+	getIssues.Stdout = new(bytes.Buffer)
 	err = getIssues.Run()
 	if err != nil {
 		return "createFailureIssue error: failed to search existing issues", err
@@ -307,7 +307,7 @@ func createFailureIssue(ctx upgrade.Context, repoOrg string, repoName string) (s
 		Title  string `json:"title"`
 		Number int    `json:"number"`
 	}{}
-	err = json.Unmarshal(bytes2.Bytes(), &titles)
+	err = json.Unmarshal(getIssues.Stdout.Bytes(), &titles)
 	if err != nil {
 		return "createFailureIssue error: failed to unmarshal `gh search issues` output", err
 	}
@@ -317,7 +317,7 @@ func createFailureIssue(ctx upgrade.Context, repoOrg string, repoName string) (s
 		cmd := exec.Command(
 			"gh", "issue", "create",
 			"--repo="+repoOrg+"/"+repoName,
-			"--body="+fmt.Sprintf("View the latest workflow run: %s", workflowUrl),
+			"--body=View the latest workflow run: "+workflowUrl,
 			"--title="+title,
 			"--label="+"needs-triage",
 		)

--- a/main.go
+++ b/main.go
@@ -297,6 +297,7 @@ func createFailureIssue(ctx upgrade.Context, repoOrg string, repoName string) (s
 		"--repo="+repoOrg+"/"+repoName,
 		"--json=title,number",
 		"--state=open",
+		"--author=pulumi-bot",
 	)
 	getIssues.Stdout = new(bytes.Buffer)
 	err = getIssues.Run()


### PR DESCRIPTION
Resolves #97 

This PR creates an issue in the targeted provider repo when `upgrade-provider` fails. The title is `Upgrade provider failure: {year} {month} {date}`. 
It looks for existing issues of the form `Upgrade provider failure: ` first, and deletes them if existing, since we likely only need to be aware of the latest upgrade failure. 
The issue body is the error message emitted from the `upgrade-provider` attempt.
It adds the "needs-triage" label (teams are not allowed to be passed as the `--assignee`, so couldn't use `pulumi/Ecosystem` for example)