### PR TITLE
Remove sdk upgrade step from --all flag

### DIFF
--- a/main.go
+++ b/main.go
@@ -103,13 +103,20 @@ func cmd() *cobra.Command {
 				case "all":
 					context.UpgradeBridgeVersion = true
 					context.UpgradeProviderVersion = true
-					context.UpgradeSdkVersion = true
 					if experimental {
 						context.UpgradeCodeMigration = true
 					}
+
 					if len(upgradeKind) > 1 {
-						warnedAll = true
-						warn("`--kind=all` implies all other options")
+						for _, v := range upgradeKind {
+							if v == "sdk" {
+								context.UpgradeSdkVersion = true
+							}
+						}
+						if !context.UpgradeSdkVersion {
+							warnedAll = true
+							warn("`--kind=all` implies all of bridge,provider,code options")
+						}
 					}
 				case "bridge":
 					set(&context.UpgradeBridgeVersion)
@@ -121,7 +128,7 @@ func cmd() *cobra.Command {
 					set(&context.UpgradeSdkVersion)
 				default:
 					return fmt.Errorf(
-						"--kind=%s invalid. Must be one of `all`, `bridge`, `provider`, or `code`.",
+						"--kind=%s invalid. Must be one of `all`, `bridge`, `provider`, `code`, or `sdk`.",
 						upgradeKind)
 				}
 			}


### PR DESCRIPTION
Fixes #96.

A successful upgrade PR using these changes can be seen [on pulumi-civo](https://github.com/pulumi/pulumi-civo/pull/242/files#diff-0301265a2d4321ca487bbd7ba523f69633171cef680c0114e7ca8d2c34176b73R10)
As you can see, we did not upgrade the Pulumi version explicitly and yet go mod tidy pulled in the version the bridge is currently using, 3.71.0.

I did discover an issue with the new pr-reviewers flag; issue to follow.
