### PR TITLE
Surround flag arguments with quotes

### DIFF
--- a/upgrade/steps.go
+++ b/upgrade/steps.go
@@ -310,15 +310,11 @@ func InformGitHub(
 		panic("Unknown action")
 	}
 
-	reviewerFlag := ""
-	if ctx.PrReviewers != "" {
-		reviewerFlag = fmt.Sprintf("--reviewer=\"%s\"", ctx.PrReviewers)
-	}
 	createPR := step.Cmd(exec.CommandContext(ctx, "gh", "pr", "create",
 		"--assignee", "@me",
 		"--base", repo.defaultBranch,
 		"--head", repo.workingBranch,
-		reviewerFlag,
+		"--reviewer", ctx.PrReviewers,
 		"--title", prTitle,
 		"--body", prBody(ctx, repo, target, goMod, targetBridgeVersion),
 	)).In(&repo.root)

--- a/upgrade/steps.go
+++ b/upgrade/steps.go
@@ -312,7 +312,7 @@ func InformGitHub(
 
 	reviewerFlag := ""
 	if ctx.PrReviewers != "" {
-		reviewerFlag = fmt.Sprintf("--reviewer=%s", ctx.PrReviewers)
+		reviewerFlag = fmt.Sprintf("--reviewer=\"%s\"", ctx.PrReviewers)
 	}
 	createPR := step.Cmd(exec.CommandContext(ctx, "gh", "pr", "create",
 		"--assignee", "@me",


### PR DESCRIPTION
Fixes #100 

Flag arguments with spaces need to be surrounded by quotes