### PR TITLE
Standalone flag for creating upgrade failure issue in CI

### DIFF
--- a/main.go
+++ b/main.go
@@ -147,7 +147,7 @@ func cmd() *cobra.Command {
 		},
 		Run: func(_ *cobra.Command, args []string) {
 			err := upgrade.UpgradeProvider(context, repoOrg, repoName)
-			if err != nil && context.InferVersion {
+			if err != nil && context.CreateFailureIssue {
 				// $GITHUB_ACTION is a default env var within github
 				// actions, but is unlikely to be defined elsewhere.
 				//
@@ -212,6 +212,9 @@ Required unless running from provider root and set in upgrade-config.yml.`)
 	cmd.PersistentFlags().BoolVarP(&context.AllowMissingDocs, "allow-missing-docs", "", false,
 		`If true, don't error on missing docs during tfgen.
 This is equivalent to setting PULUMI_MISSING_DOCS_ERROR=${! VALUE}.`)
+
+	cmd.PersistentFlags().BoolVar(&context.CreateFailureIssue, "create-failure-issue", false,
+		`Create an issue in the target repository if the upgrade attempt fails in CI.`)
 
 	return cmd
 }

--- a/upgrade/util.go
+++ b/upgrade/util.go
@@ -31,9 +31,10 @@ type Context struct {
 	UpgradeCodeMigration bool
 	MigrationOpts        []string
 
-	RemovePlugins    bool
-	AllowMissingDocs bool
-	PrReviewers      string
+	AllowMissingDocs   bool
+	RemovePlugins      bool
+	PrReviewers        string
+	CreateFailureIssue bool
 }
 
 func (c *Context) SetRepoPath(p string) {


### PR DESCRIPTION
Since we have a more general GH workflow failure system being rolled out, we can change this to be opt-in for other users