### PR TITLE
Keep `pu/pkg` up to date between examples and provider directories

### DIFF
--- a/main.go
+++ b/main.go
@@ -107,6 +107,7 @@ func cmd() *cobra.Command {
 				case "all":
 					context.UpgradeBridgeVersion = true
 					context.UpgradeProviderVersion = true
+					context.UpgradeSdkVersion = true
 					if experimental {
 						context.UpgradeCodeMigration = true
 					}

--- a/main.go
+++ b/main.go
@@ -107,7 +107,6 @@ func cmd() *cobra.Command {
 				case "all":
 					context.UpgradeBridgeVersion = true
 					context.UpgradeProviderVersion = true
-					context.UpgradeSdkVersion = true
 					if experimental {
 						context.UpgradeCodeMigration = true
 					}

--- a/upgrade/upgrade-provider.go
+++ b/upgrade/upgrade-provider.go
@@ -297,7 +297,10 @@ func UpgradeProvider(ctx Context, repoOrg, repoName string) error {
 				In(repo.providerDir()),
 			step.Cmd(exec.CommandContext(ctx,
 				"go", "get", "github.com/pulumi/pulumi/pkg/v3")).
-				In(repo.providerDir())))
+				In(repo.providerDir())),
+			step.Cmd(exec.CommandContext(ctx,
+				"go", "get", "github.com/pulumi/pulumi/pkg/v3")).
+				In(repo.examplesDir()))
 	}
 
 	if ctx.UpgradeCodeMigration {

--- a/upgrade/upgrade-provider.go
+++ b/upgrade/upgrade-provider.go
@@ -299,6 +299,9 @@ func UpgradeProvider(ctx Context, repoOrg, repoName string) error {
 				"go", "get", "github.com/pulumi/pulumi/pkg/v3")).
 				In(repo.providerDir())),
 			step.Cmd(exec.CommandContext(ctx,
+				"go", "get", "github.com/pulumi/pulumi/sdk/v3")).
+				In(repo.examplesDir()),
+			step.Cmd(exec.CommandContext(ctx,
 				"go", "get", "github.com/pulumi/pulumi/pkg/v3")).
 				In(repo.examplesDir()))
 	}


### PR DESCRIPTION
Keep ./examples/go.mod github.com/pulumi/pulumi/pkg/v3 version in line with ./provider/go.mod version
Fixes #102 