### PR TITLE
Fix argument order to `gitRefsOf`

### DIFF
--- a/upgrade/steps.go
+++ b/upgrade/steps.go
@@ -215,8 +215,8 @@ func UpgradeProviderVersion(
 		// It they are versioning correctly, `go mod tidy` will resolve the SHA to a tag.
 		steps = append(steps,
 			step.F("Lookup Tag SHA", func() (string, error) {
-				refs, err := gitRefsOf(ctx, "tags",
-					"https://"+modPathWithoutVersion(goMod.Upstream.Path))
+				refs, err := gitRefsOf(ctx, "https://"+modPathWithoutVersion(goMod.Upstream.Path),
+					"tags")
 				if err != nil {
 					return "", err
 				}


### PR DESCRIPTION
Order of arguments just needs to be flipped, was causing failures such as https://github.com/pulumi/pulumi-artifactory/actions/runs/5625475142/job/15244327189