### PR TITLE
Add update plugin framework as an option

### DIFF
--- a/main.go
+++ b/main.go
@@ -107,6 +107,7 @@ func cmd() *cobra.Command {
 				case "all":
 					context.UpgradeBridgeVersion = true
 					context.UpgradeProviderVersion = true
+					context.UpgradePfVersion = true
 					if experimental {
 						context.UpgradeCodeMigration = true
 					}
@@ -186,7 +187,7 @@ If the passed version does not exist, an error is signaled.`)
 
 	cmd.PersistentFlags().StringSliceVar(&upgradeKind, "kind", []string{"all"},
 		`The kind of upgrade to perform:
-- "all":     Upgrade the upstream provider and the bridge. Shorthand for "bridge,provider,code".
+- "all":     Upgrade the upstream provider and the bridge. Shorthand for "bridge,provider,code,pf".
 - "bridge":  Upgrade the bridge only.
 - "provider": Upgrade the upstream provider only.
 - "sdk": Upgrade the Pulumi sdk only.

--- a/main.go
+++ b/main.go
@@ -130,6 +130,8 @@ func cmd() *cobra.Command {
 					set(&context.UpgradeCodeMigration)
 				case "sdk":
 					set(&context.UpgradeSdkVersion)
+				case "pf":
+					set(&context.UpgradePfVersion)
 				default:
 					return fmt.Errorf(
 						"--kind=%s invalid. Must be one of `all`, `bridge`, `provider`, `code`, or `sdk`.",
@@ -188,6 +190,7 @@ If the passed version does not exist, an error is signaled.`)
 - "bridge":  Upgrade the bridge only.
 - "provider": Upgrade the upstream provider only.
 - "sdk": Upgrade the Pulumi sdk only.
+- "pf": Upgrade the Plugin Framework only.
 - "code":     Perform some number of code migrations.`)
 
 	cmd.PersistentFlags().BoolVar(&experimental, "experimental", false,

--- a/upgrade/kind.go
+++ b/upgrade/kind.go
@@ -99,10 +99,13 @@ func GetRepoKind(ctx Context, repo ProviderRepo) (*GoMod, error) {
 	} else if !ok {
 		return nil, fmt.Errorf(bridgeMissingMsg)
 	}
+
 	pf, ok, err := originalGoVersionOf(ctx, repo, filepath.Join("provider", "go.mod"), "github.com/pulumi/pulumi-terraform-bridge/pf")
-	if (err != nil || !ok) && ctx.UpgradePfVersion {
-		fmt.Println("No version of github.com/pulumi/pulumi-terraform-bridge/pf detected")
-		ctx.UpgradePfVersion = false
+	if err != nil {
+		return nil, err
+	}
+	if !ok && ctx.UpgradeProviderVersion {
+		setFalse(&ctx.UpgradeProviderVersion)
 	}
 
 	tfProviderRepoName := ctx.UpstreamProviderName
@@ -207,4 +210,8 @@ func GetRepoKind(ctx Context, repo ProviderRepo) (*GoMod, error) {
 	}
 
 	return &out, nil
+}
+
+func setFalse(b *bool) {
+	*b = false
 }

--- a/upgrade/kind.go
+++ b/upgrade/kind.go
@@ -99,6 +99,11 @@ func GetRepoKind(ctx Context, repo ProviderRepo) (*GoMod, error) {
 	} else if !ok {
 		return nil, fmt.Errorf(bridgeMissingMsg)
 	}
+	pf, ok, err := originalGoVersionOf(ctx, repo, filepath.Join("provider", "go.mod"), "github.com/pulumi/pulumi-terraform-bridge/pf")
+	if (err != nil || !ok) && ctx.UpgradePfVersion {
+		fmt.Println("No version of github.com/pulumi/pulumi-terraform-bridge/pf detected")
+		ctx.UpgradePfVersion = false
+	}
 
 	tfProviderRepoName := ctx.UpstreamProviderName
 
@@ -182,6 +187,7 @@ func GetRepoKind(ctx Context, repo ProviderRepo) (*GoMod, error) {
 		Upstream: upstream.Mod,
 		Fork:     fork,
 		Bridge:   bridge,
+		Pf:       pf,
 	}
 	// get the org name that hosts the upstream repo
 	tok := strings.Split(modPathWithoutVersion(upstream.Mod.Path), "/")

--- a/upgrade/steps-helpers.go
+++ b/upgrade/steps-helpers.go
@@ -117,6 +117,10 @@ func prBody(ctx Context, repo ProviderRepo,
 		fmt.Fprintf(b, "- Upgrading pulumi-terraform-bridge from %s to %s.\n",
 			goMod.Bridge.Version, targetBridge)
 	}
+	if ctx.UpgradePfVersion {
+		fmt.Fprintf(b, "- Upgrading pulumi-terraform-bridge/pf from %s to %s.\n",
+			goMod.Pf.Version, targetBridge)
+	}
 	if parts := strings.Split(tfSDKUpgrade, " -> "); len(parts) == 2 {
 		fmt.Fprintf(b, "- Upgrading pulumi/terraform-plugin-sdk from %s to %s.\n",
 			parts[0], parts[1])

--- a/upgrade/steps.go
+++ b/upgrade/steps.go
@@ -293,7 +293,7 @@ func UpgradeProviderVersion(
 
 func InformGitHub(
 	ctx Context, target *UpstreamUpgradeTarget, repo ProviderRepo,
-	goMod *GoMod, targetBridgeVersion, tfSDKUpgrade string,
+	goMod *GoMod, targetBridgeVersion, targetPfVersion, tfSDKUpgrade string,
 ) step.Step {
 	pushBranch := step.Cmd(exec.CommandContext(ctx, "git", "push", "--set-upstream",
 		"origin", repo.workingBranch)).In(&repo.root)
@@ -306,6 +306,8 @@ func InformGitHub(
 		prTitle = "Upgrade pulumi-terraform-bridge to " + targetBridgeVersion
 	} else if ctx.UpgradeCodeMigration {
 		prTitle = fmt.Sprintf("Code migration: %s", strings.Join(ctx.MigrationOpts, ", "))
+	} else if ctx.UpgradePfVersion {
+		prTitle = "Upgrade pulumi-terraform-bridge/pf to " + targetPfVersion
 	} else {
 		panic("Unknown action")
 	}

--- a/upgrade/upgrade-provider.go
+++ b/upgrade/upgrade-provider.go
@@ -9,7 +9,6 @@ import (
 	"sort"
 	"strings"
 
-	semver "github.com/Masterminds/semver/v3"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 	"golang.org/x/mod/module"
 	goSemver "golang.org/x/mod/semver"
@@ -182,19 +181,10 @@ func UpgradeProvider(ctx Context, repoOrg, repoName string) error {
 				if err != nil {
 					return "", err
 				}
-				sortedRefs := refs.sortedLabels(func(a string, b string) bool { return a > b })
-
-				var targetVersion semver.Version
-				for _, r := range sortedRefs {
-					if v := strings.TrimPrefix(r, "refs/tags/pf/"); v != r {
-						if targetVersion.LessThan(semver.MustParse(v)) {
-							targetVersion = *semver.MustParse(v)
-						}
-					}
-				}
+				targetVersion := latestSemverTag("pf/", refs)
 
 				// If our target upgrade version is the same as our current version, we skip the update.
-				if targetVersion.String() == goMod.Pf.Version {
+				if targetVersion.Original() == goMod.Pf.Version {
 					ctx.UpgradePfVersion = false
 					return fmt.Sprintf("Up to date at %s", targetVersion.String()), nil
 				}

--- a/upgrade/upgrade-provider.go
+++ b/upgrade/upgrade-provider.go
@@ -9,6 +9,7 @@ import (
 	"sort"
 	"strings"
 
+	semver "github.com/Masterminds/semver/v3"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 	"golang.org/x/mod/module"
 	goSemver "golang.org/x/mod/semver"

--- a/upgrade/upgrade-provider.go
+++ b/upgrade/upgrade-provider.go
@@ -291,6 +291,11 @@ func UpgradeProvider(ctx Context, repoOrg, repoName string) error {
 				"go", "get", "github.com/pulumi/pulumi/pkg/v3")).
 				In(repo.examplesDir()))
 	}
+	if ctx.UpgradePfVersion {
+		steps = append(steps, step.Cmd(exec.CommandContext(ctx,
+			"go", "get", "github.com/pulumi/pulumi-terraform-bridge/pf")).
+			In(repo.providerDir()))
+	}
 
 	if ctx.UpgradeCodeMigration {
 		applied := make(map[string]struct{})

--- a/upgrade/util.go
+++ b/upgrade/util.go
@@ -86,6 +86,7 @@ type GoMod struct {
 	Upstream module.Version
 	Fork     *modfile.Replace
 	Bridge   module.Version
+	Pf       module.Version
 
 	UpstreamProviderOrg string
 }

--- a/upgrade/util.go
+++ b/upgrade/util.go
@@ -23,6 +23,7 @@ type Context struct {
 
 	UpgradeBridgeVersion bool
 	UpgradeSdkVersion    bool
+	UpgradePfVersion     bool
 
 	UpgradeProviderVersion bool
 	MajorVersionBump       bool


### PR DESCRIPTION
Fixes #89 

Add option to update plugin framework (i.e. `upgrade-provider --kind=pf`). 