### PR TITLE
Upgrade correctly when the bridge has released `pf/*`

### DIFF
--- a/upgrade/steps-helpers.go
+++ b/upgrade/steps-helpers.go
@@ -324,10 +324,13 @@ func gitRefsOf(ctx context.Context, url, kind string) (gitRepoRefs, error) {
 			i, line)
 		refsToBranches[parts[0]] = parts[1]
 	}
-	return gitRepoRefs{refsToBranches}, nil
+	return gitRepoRefs{refsToBranches, kind}, nil
 }
 
-type gitRepoRefs struct{ refsToLabel map[string]string }
+type gitRepoRefs struct{
+	refsToLabel map[string]string
+	kind string
+}
 
 func (g gitRepoRefs) shaOf(label string) (string, bool) {
 	for ref, l := range g.refsToLabel {


### PR DESCRIPTION
Fixes #124 

Switches from using the latest release to using the latest tagged version for the bridge. This is necessary since some releases don't correspond to semver updates of the bridge itself.