### PR TITLE
Correctly upgrade sdk/go.mod during major version bumps

### DIFF
--- a/upgrade/util.go
+++ b/upgrade/util.go
@@ -81,6 +81,11 @@ func (p ProviderRepo) examplesDir() *string {
 	return &dir
 }
 
+func (p ProviderRepo) sdkDir() *string {
+	dir := filepath.Join(p.root, "sdk")
+	return &dir
+}
+
 type GoMod struct {
 	Kind     RepoKind
 	Upstream module.Version


### PR DESCRIPTION
This normalizes how we modify `sdk/go.mod`, and in doing so corrects the string we are modifying so it actually works.

Fixes https://github.com/pulumi/upgrade-provider/issues/123