### PR TITLE
Clarify upstream provider name

### DIFF
--- a/main.go
+++ b/main.go
@@ -85,6 +85,12 @@ func cmd() *cobra.Command {
 			// Require `upstream-provider-name` to be set
 			if context.UpstreamProviderName == "" {
 				return errors.New("`upstream-provider-name` must be provided")
+			} else if strings.ContainsRune(context.UpstreamProviderName, '/') {
+				var s string
+				if split := strings.Split(context.UpstreamProviderName, "/"); len(split) > 1 {
+					s = fmt.Sprintf(": try %q", split[len(split)-1])
+				}
+				return fmt.Errorf(`"upstream-provider-name" must not be fully qualified%s`, s)
 			}
 
 			// Validate that targetVersion is a valid version

--- a/upgrade/steps-helpers.go
+++ b/upgrade/steps-helpers.go
@@ -458,11 +458,12 @@ func getExpectedTargetLatest(ctx Context, name, upstreamOrg string) (*UpstreamUp
 	latest.Stdout = bytes
 	err := latest.Run()
 	if err != nil {
-		return nil, "", err
+		return nil, "", fmt.Errorf("%v: %w", latest.Args, err)
 	}
 
 	tok := strings.Fields(bytes.String())
-	contract.Assertf(len(tok) > 0, fmt.Sprintf("no releases found in %s/%s", upstreamOrg, ctx.UpstreamProviderName))
+	contract.Assertf(len(tok) > 0, fmt.Sprintf("no releases found in %s/%s",
+		upstreamOrg, ctx.UpstreamProviderName))
 	v, err := semver.NewVersion(tok[0])
 	if err != nil {
 		return nil, "", err

--- a/upgrade/upgrade-provider.go
+++ b/upgrade/upgrade-provider.go
@@ -69,7 +69,7 @@ func UpgradeProvider(ctx Context, repoOrg, repoName string) error {
 				upgradeTarget, msg, err = GetExpectedTarget(ctx, repoOrg+"/"+repoName,
 					goMod.UpstreamProviderOrg)
 				if err != nil {
-					return "", err
+					return "", fmt.Errorf("expected target: %w", err)
 				}
 				if upgradeTarget == nil {
 					return "", errors.New("could not determine an upstream version")

--- a/upgrade/util.go
+++ b/upgrade/util.go
@@ -28,6 +28,12 @@ type Context struct {
 	UpgradeProviderVersion bool
 	MajorVersionBump       bool
 
+	// The unqualified name of the upstream provider.
+	//
+	// As an example, Pulumi's AWS provider has:
+	//
+	//	pulumi-aws
+	//
 	UpstreamProviderName string
 
 	UpgradeCodeMigration bool


### PR DESCRIPTION
Clarify that `--upstream-provider-name` is the unqualified name of the provider.