### PR TITLE
Skip upstream upgrade when target = current

### DIFF
--- a/colorize/colorize.go
+++ b/colorize/colorize.go
@@ -1,5 +1,7 @@
 package colorize
 
+import "fmt"
+
 const (
 	esc   = "\u001B["
 	bold  = esc + "1m"
@@ -7,10 +9,8 @@ const (
 	reset = esc + "m"
 )
 
-func Bold(s string) string {
-	return bold + s + reset
-}
+func Bold(s string) string { return bold + s + reset }
+func Warn(s string) string { return warn + s + reset }
 
-func Warn(s string) string {
-	return warn + s + reset
-}
+func Boldf(msg string, a ...any) string { return Bold(fmt.Sprintf(msg, a...)) }
+func Warnf(msg string, a ...any) string { return Warn(fmt.Sprintf(msg, a...)) }

--- a/upgrade/steps-helpers.go
+++ b/upgrade/steps-helpers.go
@@ -520,8 +520,20 @@ func getExpectedTargetFromIssues(ctx Context, name string) (*UpstreamUpgradeTarg
 		return versions[j].Version.LessThan(versions[i].Version)
 	})
 
-	if ctx.TargetVersion != nil && !versions[0].Version.Equal(ctx.TargetVersion) {
-		return nil, fmt.Errorf("possible upgrades exist, but non match %s", ctx.TargetVersion)
+	if ctx.TargetVersion != nil {
+		var foundTarget bool
+		for i, v := range versions {
+			if v.Version.Equal(ctx.TargetVersion) {
+				// Change the target version to be the latest that we
+				// found.
+				versions = versions[i:]
+				foundTarget = true
+				break
+			}
+		}
+		if !foundTarget {
+			return nil, fmt.Errorf("possible upgrades exist, but none match %s", ctx.TargetVersion)
+		}
 	}
 
 	target.GHIssues = versions


### PR DESCRIPTION
This case was handled when `ctx.InferVersion`, but not handled correctly when the upstream
version came directly from GitHub.