### PR TITLE
Upgrade plugin sdk after bridge upgrade

### DIFF
--- a/upgrade/steps.go
+++ b/upgrade/steps.go
@@ -193,21 +193,6 @@ func UpgradeProviderVersion(
 			step.Cmd(exec.CommandContext(ctx, "make", "upstream")).In(&repo.root),
 		))
 	}
-	// We first check if the provider is patched, and ensure the upstream is initialized if so.
-	updateLatestPluginSDK, didUpdate := getLatestTFPluginSDKReplace(ctx, repo)
-	// We then start by updating the terraform-plugin-sdk because later updates sometimes
-	// rely on it.
-
-	steps = append(steps, updateLatestPluginSDK,
-		// If we updated the pinned plugin sdk, then we need to run `go mod tidy`
-		// to normalize the ref.
-		step.Computed(func() step.Step {
-			if !(*didUpdate) {
-				return nil
-			}
-			return step.Cmd(exec.CommandContext(ctx, "go", "mod", "tidy")).
-				In(repo.providerDir())
-		}))
 
 	if !goMod.Kind.IsForked() {
 		// We have an upstream we don't control, so we need to get it's SHA. We do this

--- a/upgrade/upgrade-provider.go
+++ b/upgrade/upgrade-provider.go
@@ -377,15 +377,16 @@ func UpgradeProvider(ctx Context, repoOrg, repoName string) error {
 		}
 	}
 
-	addPluginStep := step.Cmd(exec.CommandContext(ctx, "pulumi", "plugin", "rm", "--all", "--yes"))
-	if !ctx.RemovePlugins {
-		addPluginStep = step.Cmd(exec.Command("echo", "Plugins not removed."))
-	}
-
 	artifacts := append(steps,
 		step.Cmd(exec.CommandContext(ctx, "go", "mod", "tidy")).In(repo.providerDir()),
 		step.Cmd(exec.CommandContext(ctx, "go", "mod", "tidy")).In(repo.examplesDir()),
-		addPluginStep,
+		step.Computed(func() step.Step {
+			if ctx.RemovePlugins {
+				return step.Cmd(exec.CommandContext(ctx,
+					"pulumi", "plugin", "rm", "--all", "--yes"))
+			}
+			return nil
+		}),
 		step.Cmd(exec.CommandContext(ctx, "make", "tfgen")).In(&repo.root),
 		step.Cmd(exec.CommandContext(ctx, "git", "add", "--all")).In(&repo.root),
 		GitCommit(ctx, "make tfgen").In(&repo.root),


### PR DESCRIPTION
Attempt to upgrade `pulumi/terraform-plugin-sdk` after each bridge upgrade. We do this because the bridge might use new features of `pulumi/terraform-plugin-sdk`, thus failing to compile on old versions.

Stacked on top of https://github.com/pulumi/upgrade-provider/pull/136.