### PR TITLE
Add functionality to upgrade Pulumi version in `sdk/go.mod`

### DIFF
--- a/upgrade/steps-helpers.go
+++ b/upgrade/steps-helpers.go
@@ -121,6 +121,10 @@ func prBody(ctx Context, repo ProviderRepo,
 		fmt.Fprintf(b, "- Upgrading pulumi-terraform-bridge/pf from %s to %s.\n",
 			goMod.Pf.Version, targetBridge)
 	}
+
+	if ctx.UpgradeSdkVersion {
+		fmt.Fprintf(b, "- Upgrading pulumi SDK to `latest`.\n")
+	}
 	if parts := strings.Split(tfSDKUpgrade, " -> "); len(parts) == 2 {
 		fmt.Fprintf(b, "- Upgrading pulumi/terraform-plugin-sdk from %s to %s.\n",
 			parts[0], parts[1])


### PR DESCRIPTION
This pull request adds two steps to the upgrader:
- `getNewPulumiVersionStep` to obtain the pulumi SDK version in `resources.go` after a bridge update
- `updateToBridgePulumiVersionStep` to sed `sdk/go.mod` to the same pulumi SDK version the bridge is currently requiring.

We also fix a bug where `upgrade-provider --kind=sdk` hit the default case. It is now possible to upgrade SDK only.

A successful upgrade PR that used this code: https://github.com/pulumi/pulumi-artifactory/pull/441

Fixes #134.

- Add steps to read pulumi sdk version from provider/go.mod and read it into sdk/go.mod in case of a bridge update
- Fix up prBody for a plain pulumi --> latest upgrade
