### PR TITLE
Always run the TF Plugin SDK Upgrader

### DIFF
--- a/upgrade/steps.go
+++ b/upgrade/steps.go
@@ -338,43 +338,10 @@ func InformGitHub(
 //
 // This is predicated on updating to the latest version being safe. We will need to
 // revisit this when a new major version of the plugin SDK is released.
-func getLatestTFPluginSDKReplace(ctx context.Context, repo ProviderRepo, targetSHA *string) step.Step {
+func setTFPluginSDKReplace(ctx context.Context, repo ProviderRepo, targetSHA *string) step.Step {
 	// We do discover in a step.Computed so if the fork isn't present, it isn't
 	// displayed to the user.
 	return step.F("Update TF Plugin SDK Fork", func() (string, error) {
-		// If the fork is present, we need to figure out the SHA of the
-		// latest upstream version to use.
-		const hostRepo = "https://github.com/pulumi/terraform-plugin-sdk.git"
-		result, err := exec.CommandContext(ctx, "git",
-			"ls-remote", "--heads", hostRepo).Output()
-		if err != nil {
-			return "", fmt.Errorf("could not get branches: %w", err)
-		}
-		lines := strings.Split(string(result), "\n")
-		versions := make([]*semver.Version, len(lines))
-		shas := make([]string, len(lines))
-		highest := -1
-		for i, line := range lines {
-			split := strings.Split(strings.TrimSpace(line), "\t")
-			if len(split) < 2 {
-				continue
-			}
-			shas[i] = split[0]
-			version, hasVersion := strings.CutPrefix(split[1], "refs/heads/upstream-")
-			if !hasVersion {
-				continue
-			}
-			if v, err := semver.NewVersion(version); err == nil {
-				versions[i] = v
-				if highest == -1 || versions[highest].LessThan(v) {
-					highest = i
-				}
-			}
-		}
-		if highest == -1 {
-			return "", fmt.Errorf("no upstream version found")
-		}
-
 		goModFile, err := os.ReadFile("go.mod")
 		if err != nil {
 			return "", fmt.Errorf("could not find go.mod: %w", err)

--- a/upgrade/steps.go
+++ b/upgrade/steps.go
@@ -17,7 +17,6 @@ import (
 	semver "github.com/Masterminds/semver/v3"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 	"golang.org/x/mod/modfile"
-	"golang.org/x/mod/module"
 	"gopkg.in/yaml.v3"
 
 	"github.com/pulumi/upgrade-provider/step"
@@ -339,116 +338,69 @@ func InformGitHub(
 //
 // This is predicated on updating to the latest version being safe. We will need to
 // revisit this when a new major version of the plugin SDK is released.
-func getLatestTFPluginSDKReplace(ctx context.Context, repo ProviderRepo) (step.Step, *bool) {
-	name := "Update TF Plugin SDK Fork"
-	stepFail := func(msg string, a ...any) step.Step {
-		return step.F(name, func() (string, error) {
-			return "", fmt.Errorf(msg, a...)
-		})
-	}
-
-	didReplace := new(bool)
-
+func getLatestTFPluginSDKReplace(ctx context.Context, repo ProviderRepo, targetSHA *string) step.Step {
 	// We do discover in a step.Computed so if the fork isn't present, it isn't
 	// displayed to the user.
-	return step.Computed(func() step.Step {
+	return step.F("Update TF Plugin SDK Fork", func() (string, error) {
+		// If the fork is present, we need to figure out the SHA of the
+		// latest upstream version to use.
+		const hostRepo = "https://github.com/pulumi/terraform-plugin-sdk.git"
+		result, err := exec.CommandContext(ctx, "git",
+			"ls-remote", "--heads", hostRepo).Output()
+		if err != nil {
+			return "", fmt.Errorf("could not get branches: %w", err)
+		}
+		lines := strings.Split(string(result), "\n")
+		versions := make([]*semver.Version, len(lines))
+		shas := make([]string, len(lines))
+		highest := -1
+		for i, line := range lines {
+			split := strings.Split(strings.TrimSpace(line), "\t")
+			if len(split) < 2 {
+				continue
+			}
+			shas[i] = split[0]
+			version, hasVersion := strings.CutPrefix(split[1], "refs/heads/upstream-")
+			if !hasVersion {
+				continue
+			}
+			if v, err := semver.NewVersion(version); err == nil {
+				versions[i] = v
+				if highest == -1 || versions[highest].LessThan(v) {
+					highest = i
+				}
+			}
+		}
+		if highest == -1 {
+			return "", fmt.Errorf("no upstream version found")
+		}
+
 		goModFile, err := os.ReadFile("go.mod")
 		if err != nil {
-			return stepFail("could not fine go.mod: %w", err)
+			return "", fmt.Errorf("could not find go.mod: %w", err)
 		}
 		goMod, err := modfile.Parse("go.mod", goModFile, nil)
 		if err != nil {
-			return stepFail("could not parse go.mod: %w", err)
+			return "", fmt.Errorf("failed to parse go.mod: %w", err)
 		}
 
-		const targetSrc = "github.com/hashicorp/terraform-plugin-sdk/v2"
-
-		var require *modfile.Require
-		for _, r := range goMod.Require {
-			if r.Mod.Path == targetSrc {
-				require = r
-			}
-		}
-		if require == nil {
-			return nil
+		// Otherwise, we need to replace the old version. goMod.AddReplace
+		// will handle replacing existing `replace` directives.
+		err = goMod.AddReplace("github.com/hashicorp/terraform-plugin-sdk/v2", "",
+			"github.com/pulumi/terraform-plugin-sdk/v2", *targetSHA)
+		if err != nil {
+			return "", fmt.Errorf("failed to update version: %w", err)
 		}
 
-		var replace *modfile.Replace
-		for _, r := range goMod.Replace {
-			if r.Old.Path == targetSrc {
-				replace = r
-				break
-			}
+		// We now write out the new file over the old file.
+		goMod.Cleanup()
+		goModFile, err = goMod.Format()
+		if err != nil {
+			return "", fmt.Errorf("failed to format file as bytes: %w", err)
 		}
-		if replace == nil {
-			return nil
-		}
-
-		return step.F(name, func() (string, error) {
-			// If the fork is present, we need to figure out the SHA of the
-			// latest upstream version to use.
-			const hostRepo = "https://github.com/pulumi/terraform-plugin-sdk.git"
-			result, err := exec.CommandContext(ctx, "git",
-				"ls-remote", "--heads", hostRepo).Output()
-			if err != nil {
-				return "", fmt.Errorf("could not get branches: %w", err)
-			}
-			lines := strings.Split(string(result), "\n")
-			versions := make([]*semver.Version, len(lines))
-			shas := make([]string, len(lines))
-			highest := -1
-			for i, line := range lines {
-				split := strings.Split(strings.TrimSpace(line), "\t")
-				if len(split) < 2 {
-					continue
-				}
-				shas[i] = split[0]
-				version, hasVersion := strings.CutPrefix(split[1], "refs/heads/upstream-")
-				if !hasVersion {
-					continue
-				}
-				if v, err := semver.NewVersion(version); err == nil {
-					versions[i] = v
-					if highest == -1 || versions[highest].LessThan(v) {
-						highest = i
-					}
-				}
-			}
-			if highest == -1 {
-				return "", fmt.Errorf("no upstream version found")
-			}
-
-			// We now compare the pseudo vision and the latest SHA.
-			pseudo, err := module.PseudoVersionRev(replace.New.Version)
-			if err != nil {
-				return "", fmt.Errorf("not using a branch based replace")
-			}
-
-			// If the pseudo version matches the latest SHA, we are already up
-			// to date. We don't need to do any edits.
-			if strings.HasPrefix(shas[highest], pseudo) {
-				return "already up to date", nil
-			}
-
-			// Otherwise, we need to replace the old version. goMod.AddReplace
-			// will handle replacing existing `replace` directives.
-			err = goMod.AddReplace(replace.Old.Path, replace.Old.Version,
-				replace.New.Path, shas[highest])
-			if err != nil {
-				return "", fmt.Errorf("failed to update version: %w", err)
-			}
-
-			// We now write out the new file over the old file.
-			goMod.Cleanup()
-			goModFile, err = goMod.Format()
-			if err != nil {
-				return "", fmt.Errorf("failed to format file as bytes: %w", err)
-			}
-			err = os.WriteFile("go.mod", goModFile, 0600)
-			*didReplace = true
-			return "updated", err
-		})
-	}).In(repo.providerDir()), didReplace
+		err = os.WriteFile("go.mod", goModFile, 0600)
+		return "updated", err
+	}).In(repo.providerDir())
 }
 
 func EnsureBranchCheckedOut(ctx Context, branchName string) step.Step {

--- a/upgrade/upgrade-provider.go
+++ b/upgrade/upgrade-provider.go
@@ -198,7 +198,7 @@ func UpgradeProvider(ctx Context, repoOrg, repoName string) error {
 				latestTag := fmt.Sprintf("refs/heads/upstream-%s", latest.Original())
 				latestSha, ok := refs.shaOf(latestTag)
 				contract.Assertf(ok, "Failed to lookup sha of known tag: %q not in %#v",
-					latestTag, refs.refsToLabel)
+					latestTag, refs.labelToRef)
 				tfSDKTargetSHA = latestSha
 				return fmt.Sprintf("%s -> %s", currentBranch, latest), nil
 			}).AssignTo(&tfSDKUpgrade),

--- a/upgrade/upgrade-provider.go
+++ b/upgrade/upgrade-provider.go
@@ -31,6 +31,7 @@ func UpgradeProvider(ctx Context, repoOrg, repoName string) error {
 		org:  repoOrg,
 	}
 	var targetBridgeVersion, targetPfVersion, tfSDKUpgrade string
+	var tfSDKTargetSHA string
 	var upgradeTarget *UpstreamUpgradeTarget
 	var goMod *GoMod
 
@@ -194,6 +195,11 @@ func UpgradeProvider(ctx Context, repoOrg, repoName string) error {
 				if latest.Original() == currentBranch {
 					return fmt.Sprintf("Up to date at %s", latest), nil
 				}
+				latestTag := fmt.Sprintf("refs/heads/upstream-%s", latest.Original())
+				latestSha, ok := refs.shaOf(latestTag)
+				contract.Assertf(ok, "Failed to lookup sha of known tag: %q not in %#v",
+					latestTag, refs.refsToLabel)
+				tfSDKTargetSHA = latestSha
 				return fmt.Sprintf("%s -> %s", currentBranch, latest), nil
 			}).AssignTo(&tfSDKUpgrade),
 		)
@@ -315,6 +321,17 @@ func UpgradeProvider(ctx Context, repoOrg, repoName string) error {
 		}()
 	}
 
+	steps = append(steps, step.Computed(func() step.Step {
+		// No upgrade was planned, so exit
+		if tfSDKTargetSHA == "" {
+			return nil
+		}
+		return step.Combined("Update Plugin SDK",
+			getLatestTFPluginSDKReplace(ctx, repo, &tfSDKTargetSHA),
+			step.Cmd(exec.CommandContext(ctx, "go", "mod", "tidy")).In(repo.providerDir()),
+		)
+	}))
+
 	if ctx.UpgradeProviderVersion {
 		steps = append(steps, UpgradeProviderVersion(ctx, goMod, upgradeTarget.Version, repo,
 			targetSHA, forkedProviderUpstreamCommit))
@@ -340,21 +357,6 @@ func UpgradeProvider(ctx Context, repoOrg, repoName string) error {
 		steps = append(steps, step.Cmd(exec.CommandContext(ctx,
 			"go", "mod", "tidy")).
 			In(repo.providerDir()))
-
-		// If we update the bridge, then we should update our terraform-plugin-sdk
-		// fork, since the bridge assumes that it is up to date.
-		updatePluginSDK, didUpdate := getLatestTFPluginSDKReplace(ctx, repo)
-
-		steps = append(steps, updatePluginSDK,
-			// If we updated the pinned plugin sdk, then we need to run `go mod tidy`
-			// to normalize the ref.
-			step.Computed(func() step.Step {
-				if !(*didUpdate) {
-					return nil
-				}
-				return step.Cmd(exec.CommandContext(ctx, "go", "mod", "tidy")).
-					In(repo.providerDir())
-			}))
 
 		// Now that we've updated the bridge version, we need to update the corresponding pulumi version in sdk/go.mod.
 		// It needs to match the version used in provider/go.mod, which is *not* necessarily `latest`.

--- a/upgrade/upgrade-provider.go
+++ b/upgrade/upgrade-provider.go
@@ -327,7 +327,7 @@ func UpgradeProvider(ctx Context, repoOrg, repoName string) error {
 			return nil
 		}
 		return step.Combined("Update Plugin SDK",
-			getLatestTFPluginSDKReplace(ctx, repo, &tfSDKTargetSHA),
+			setTFPluginSDKReplace(ctx, repo, &tfSDKTargetSHA),
 			step.Cmd(exec.CommandContext(ctx, "go", "mod", "tidy")).In(repo.providerDir()),
 		)
 	}))


### PR DESCRIPTION
We recently moved this from running during provider upgrades to running during bridge upgrades. We should actually upgrade in either case, since both the provider and the bridge can rely on a new version of the SDK.

---

In the past, we duplicated work; calculating the version to use in a planning step and then recalculating the SHA in the upgrade step itself. This PR calculates the SHA directly in the planning step, and then uses that in the upgrade step.

---

Example PR is https://github.com/pulumi/pulumi-aws/pull/2804.