### PR TITLE
Correctly map git tags to shas for tag discovery

### DIFF
--- a/main.go
+++ b/main.go
@@ -137,6 +137,7 @@ func cmd() *cobra.Command {
 					}
 				case "bridge":
 					set(&context.UpgradeBridgeVersion)
+					set(&context.UpgradePfVersion)
 				case "provider":
 					set(&context.UpgradeProviderVersion)
 				case "code":

--- a/upgrade/util.go
+++ b/upgrade/util.go
@@ -144,6 +144,7 @@ func latestSemverTag(prefix string, refs gitRepoRefs) *semver.Version {
 			return vA.GreaterThan(vB)
 		}
 	})
+	//fmt.Println("sorted", sorted)
 	if len(sorted) == 0 {
 		return nil
 	}


### PR DESCRIPTION
Fixes #150.

- Upgrade tfpf with a bridge update always
- These changes work on the pf-only upgrade at least
