### PR TITLE
Add extra imports to bridge update

### DIFF
--- a/upgrade/upgrade-provider.go
+++ b/upgrade/upgrade-provider.go
@@ -337,6 +337,9 @@ func UpgradeProvider(ctx Context, repoOrg, repoName string) error {
 		steps = append(steps, step.Cmd(exec.CommandContext(ctx,
 			"go", "get", "github.com/hashicorp/terraform-plugin-mux")).
 			In(repo.providerDir()))
+		steps = append(steps, step.Cmd(exec.CommandContext(ctx,
+			"go", "mod", "tidy")).
+			In(repo.providerDir()))
 
 		// If we update the bridge, then we should update our terraform-plugin-sdk
 		// fork, since the bridge assumes that it is up to date.

--- a/upgrade/upgrade-provider.go
+++ b/upgrade/upgrade-provider.go
@@ -334,6 +334,9 @@ func UpgradeProvider(ctx Context, repoOrg, repoName string) error {
 		steps = append(steps, step.Cmd(exec.CommandContext(ctx,
 			"go", "get", "github.com/hashicorp/terraform-plugin-framework")).
 			In(repo.providerDir()))
+		steps = append(steps, step.Cmd(exec.CommandContext(ctx,
+			"go", "get", "github.com/hashicorp/terraform-plugin-mux")).
+			In(repo.providerDir()))
 
 		// If we update the bridge, then we should update our terraform-plugin-sdk
 		// fork, since the bridge assumes that it is up to date.

--- a/upgrade/upgrade-provider.go
+++ b/upgrade/upgrade-provider.go
@@ -331,6 +331,10 @@ func UpgradeProvider(ctx Context, repoOrg, repoName string) error {
 			"go", "get", "github.com/pulumi/pulumi-terraform-bridge/v3@"+targetBridgeVersion)).
 			In(repo.providerDir()))
 
+		steps = append(steps, step.Cmd(exec.CommandContext(ctx,
+			"go", "get", "github.com/hashicorp/terraform-plugin-framework")).
+			In(repo.providerDir()))
+
 		// If we update the bridge, then we should update our terraform-plugin-sdk
 		// fork, since the bridge assumes that it is up to date.
 		updatePluginSDK, didUpdate := getLatestTFPluginSDKReplace(ctx, repo)


### PR DESCRIPTION
Fixes https://github.com/pulumi/pulumi-cloudflare/issues/485 et al. There are 10 providers where an automatic bridge update failed because of these dependencies not being updated.

Adds default `go get github.com/hashicorp/terraform-plugin-framework` and `go get github.com/hashicorp/terraform-plugin-mux`to bridge updates.

https://github.com/pulumi/pulumi-akamai/pull/271 and https://github.com/pulumi/pulumi-cloudflare/pull/487 are successful examples of this update.

Concern: what if we cannot upgrade to latest bridge?

- Add a go get statement for Terraform Plugin Framework when updating the bridge
- Add a go get statement for Terraform Plugin Mux when updating the bridge
