### PR TITLE
Default to latest upgrade version of Pulumi Plugin SDK

### DIFF
--- a/upgrade/upgrade-provider.go
+++ b/upgrade/upgrade-provider.go
@@ -177,9 +177,13 @@ func UpgradeProvider(ctx Context, repoOrg, repoName string) error {
 					return "", fmt.Errorf("unable to parse PseudoVersionRef %q: %w",
 						current.Version, err)
 				}
+
 				currentBranch, ok := refs.labelOf(currentRef)
 				if !ok {
-					return "", fmt.Errorf("Did not recognize branch")
+					// use latest versioned branch
+					latest := latestSemverTag("upstream-", refs)
+					return fmt.Sprintf("Could not find head branch at ref %s. Upgrading to "+
+						"latest branch at %s instead.", currentRef, latest), nil
 				}
 
 				trim := func(branch string) string {

--- a/upgrade/upgrade-provider.go
+++ b/upgrade/upgrade-provider.go
@@ -177,11 +177,10 @@ func UpgradeProvider(ctx Context, repoOrg, repoName string) error {
 					return "", fmt.Errorf("unable to parse PseudoVersionRef %q: %w",
 						current.Version, err)
 				}
-
+				latest := latestSemverTag("upstream-", refs)
 				currentBranch, ok := refs.labelOf(currentRef)
 				if !ok {
 					// use latest versioned branch
-					latest := latestSemverTag("upstream-", refs)
 					return fmt.Sprintf("Could not find head branch at ref %s. Upgrading to "+
 						"latest branch at %s instead.", currentRef, latest), nil
 				}
@@ -194,7 +193,6 @@ func UpgradeProvider(ctx Context, repoOrg, repoName string) error {
 
 				// We are guaranteed to get a non-nil result because there
 				// are semver tags released tags with this prefix.
-				latest := latestSemverTag("upstream-", refs)
 				if latest.Original() == currentBranch {
 					return fmt.Sprintf("Up to date at %s", latest), nil
 				}


### PR DESCRIPTION
When the current branch for the Plugin SDK cannot be found, log this and upgrade to latest instead.

Successfully opened PR using these changes: https://github.com/pulumi/pulumi-kong/pull/204

Fixes #158.
