### PR TITLE
Pass `context.Context` in steps.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
-upgrade-provider
 .idea/
 vendor/
+bin/

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,8 @@
+bin:
+	mkdir -p bin
 
-build: tidy
-	go build github.com/pulumi/upgrade-provider
+build: tidy bin
+	go build -o ./bin/upgrade-provider github.com/pulumi/upgrade-provider
 
 tidy:
 	go mod tidy


### PR DESCRIPTION
I'm going to try to start refactoring the step.Step library so we can use it to generate
replay tests. That will require contextual information, so I have made the decision to
pass context.Context now.

Right now that means:
- Changing `step.F` to take a `func(context.Context) (string, error)`
- Changing `step.Cmd` to take `name string, ...args` instead of an `exec.Command`.

This change will have no user facing behavior.