### PR TITLE
Hide *Context inside context.Context

### DIFF
--- a/upgrade/kind.go
+++ b/upgrade/kind.go
@@ -1,6 +1,7 @@
 package upgrade
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -78,7 +79,7 @@ func (rk RepoKind) IsPatched() bool {
 	}
 }
 
-func GetRepoKind(ctx Context, repo ProviderRepo) (*GoMod, error) {
+func GetRepoKind(ctx context.Context, repo ProviderRepo) (*GoMod, error) {
 	path := repo.root
 	file := filepath.Join(path, "provider", "go.mod")
 
@@ -104,11 +105,11 @@ func GetRepoKind(ctx Context, repo ProviderRepo) (*GoMod, error) {
 	if err != nil {
 		return nil, err
 	}
-	if !ok && ctx.UpgradeProviderVersion {
+	if ctx := GetContext(ctx); !ok && ctx.UpgradeProviderVersion {
 		setFalse(&ctx.UpgradeProviderVersion)
 	}
 
-	tfProviderRepoName := ctx.UpstreamProviderName
+	tfProviderRepoName := GetContext(ctx).UpstreamProviderName
 
 	getUpstream := func(file *modfile.File) (*modfile.Require, error) {
 		// Find the name of our upstream dependency

--- a/upgrade/steps-helpers_test.go
+++ b/upgrade/steps-helpers_test.go
@@ -1,6 +1,7 @@
 package upgrade
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -11,7 +12,7 @@ import (
 )
 
 func TestGetRepoExpectedLocation(t *testing.T) {
-	ctx := Context{
+	ctx := &Context{
 		GoPath: "/Users/myuser/go",
 	}
 
@@ -32,7 +33,7 @@ func TestGetRepoExpectedLocation(t *testing.T) {
 	for _, tt := range tests {
 		tt := tt
 		t.Run(fmt.Sprintf("(%s,%s,%s)", tt.cwd, tt.repoPath, tt.expected), func(t *testing.T) {
-			expected, err := getRepoExpectedLocation(ctx, tt.cwd, tt.repoPath)
+			expected, err := getRepoExpectedLocation(ctx.Wrap(context.Background()), tt.cwd, tt.repoPath)
 			expected = trimSeparators(expected)
 			assert.Nil(t, err)
 			assert.Equal(t, trimSeparators(tt.expected), expected)

--- a/upgrade/util.go
+++ b/upgrade/util.go
@@ -10,9 +10,15 @@ import (
 	"golang.org/x/mod/module"
 )
 
-type Context struct {
-	context.Context
+type contextKeyType struct{}
 
+var contextKey contextKeyType
+
+func GetContext(ctx context.Context) *Context {
+	return ctx.Value(contextKey).(*Context)
+}
+
+type Context struct {
 	// The user's GOPATH env var
 	GoPath string
 	// An optional path to clone the provider repo to
@@ -49,6 +55,10 @@ type Context struct {
 	PrReviewers        string
 	PrAssign           string
 	CreateFailureIssue bool
+}
+
+func (c *Context) Wrap(ctx context.Context) context.Context {
+	return context.WithValue(ctx, contextKey, c)
 }
 
 func (c *Context) SetRepoPath(p string) {


### PR DESCRIPTION
This allows multiple systems to pass context.Context without interference, normalizing function signatures. This is a pure refactor and does not have user facing changes.