### PR TITLE
Allow specifying target bridge version

### DIFF
--- a/main.go
+++ b/main.go
@@ -32,6 +32,8 @@ const (
 
 func cmd() *cobra.Command {
 	var targetVersion string
+	var targetBridgeRef string
+
 	gopath, ok := os.LookupEnv("GOPATH")
 	if !ok {
 		gopath = build.Default.GOPATH
@@ -97,6 +99,14 @@ func cmd() *cobra.Command {
 				if err != nil {
 					return fmt.Errorf("--target-version=%s: %w",
 						targetVersion, err)
+				}
+			}
+
+			if targetBridgeRef != "" {
+				context.TargetBridgeRef, err = upgrade.ParseRef(targetBridgeRef)
+				if err != nil {
+					return fmt.Errorf("--target-bridge-version=%s: %w",
+						targetBridgeRef, err)
 				}
 			}
 
@@ -237,6 +247,9 @@ This is equivalent to setting PULUMI_MISSING_DOCS_ERROR=${! VALUE}.`)
 
 	cmd.PersistentFlags().StringVar(&context.JavaVersion, "java-version", "",
 		"The version of pulumi-java-gen to target.")
+
+	cmd.PersistentFlags().StringVar(&targetBridgeRef, "target-bridge-version", "latest",
+		`The desired bridge version to upgrade to. Git hash references permitted. Defaults to "latest".`)
 
 	return cmd
 }

--- a/main.go
+++ b/main.go
@@ -249,7 +249,7 @@ This is equivalent to setting PULUMI_MISSING_DOCS_ERROR=${! VALUE}.`)
 		"The version of pulumi-java-gen to target.")
 
 	cmd.PersistentFlags().StringVar(&targetBridgeRef, "target-bridge-version", "latest",
-		`The desired bridge version to upgrade to. Git hash references permitted. Defaults to "latest".`)
+		`The desired bridge version to upgrade to. Git hash references permitted.`)
 
 	return cmd
 }

--- a/upgrade/steps-helpers.go
+++ b/upgrade/steps-helpers.go
@@ -117,7 +117,7 @@ func baseFileAt(ctx context.Context, repo ProviderRepo, file string) ([]byte, er
 
 func prBody(ctx context.Context, repo ProviderRepo,
 	upgradeTarget *UpstreamUpgradeTarget, goMod *GoMod,
-	targetBridge, tfSDKUpgrade string) string {
+	targetBridge Ref, tfSDKUpgrade string) string {
 	b := new(strings.Builder)
 	fmt.Fprintf(b, "This PR was generated via `$ upgrade-provider %s`.\n",
 		strings.Join(os.Args[1:], " "))
@@ -154,7 +154,7 @@ func prBody(ctx context.Context, repo ProviderRepo,
 			goMod.Bridge.Version, targetBridge)
 	}
 	if GetContext(ctx).UpgradePfVersion {
-		fmt.Fprintf(b, "- Upgrading pulumi-terraform-bridge/pf from %s to %s.\n",
+		fmt.Fprintf(b, "- Upgrading pulumi-terraform-bridge/pf from %s to %v.\n",
 			goMod.Pf.Version, targetBridge)
 	}
 

--- a/upgrade/steps.go
+++ b/upgrade/steps.go
@@ -306,7 +306,7 @@ func UpgradeProviderVersion(
 
 func InformGitHub(
 	ctx context.Context, target *UpstreamUpgradeTarget, repo ProviderRepo,
-	goMod *GoMod, targetBridgeVersion, targetPfVersion, tfSDKUpgrade string,
+	goMod *GoMod, targetBridgeVersion Ref, targetPfVersion, tfSDKUpgrade string,
 ) step.Step {
 	pushBranch := step.Cmd("git", "push", "--set-upstream",
 		"origin", repo.workingBranch).In(&repo.root)
@@ -316,7 +316,7 @@ func InformGitHub(
 		prTitle = fmt.Sprintf("Upgrade %s to v%s",
 			ctx.UpstreamProviderName, target.Version)
 	} else if ctx.UpgradeBridgeVersion {
-		prTitle = "Upgrade pulumi-terraform-bridge to " + targetBridgeVersion
+		prTitle = "Upgrade pulumi-terraform-bridge to " + targetBridgeVersion.String()
 	} else if ctx.UpgradeCodeMigration {
 		prTitle = fmt.Sprintf("Code migration: %s", strings.Join(ctx.MigrationOpts, ", "))
 	} else if ctx.UpgradePfVersion {

--- a/upgrade/steps.go
+++ b/upgrade/steps.go
@@ -306,7 +306,7 @@ func UpgradeProviderVersion(
 
 func InformGitHub(
 	ctx context.Context, target *UpstreamUpgradeTarget, repo ProviderRepo,
-	goMod *GoMod, targetBridgeVersion Ref, targetPfVersion, tfSDKUpgrade string,
+	goMod *GoMod, targetBridgeVersion, targetPfVersion Ref, tfSDKUpgrade string,
 ) step.Step {
 	pushBranch := step.Cmd("git", "push", "--set-upstream",
 		"origin", repo.workingBranch).In(&repo.root)
@@ -320,7 +320,7 @@ func InformGitHub(
 	} else if ctx.UpgradeCodeMigration {
 		prTitle = fmt.Sprintf("Code migration: %s", strings.Join(ctx.MigrationOpts, ", "))
 	} else if ctx.UpgradePfVersion {
-		prTitle = "Upgrade pulumi-terraform-bridge/pf to " + targetPfVersion
+		prTitle = "Upgrade pulumi-terraform-bridge/pf to " + targetPfVersion.String()
 	} else if ctx.UpgradeSdkVersion {
 		prTitle = "Upgrade Pulumi SDK dependency"
 	} else {

--- a/upgrade/upgrade-provider.go
+++ b/upgrade/upgrade-provider.go
@@ -9,11 +9,11 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/Masterminds/semver/v3"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 	"golang.org/x/mod/module"
 	goSemver "golang.org/x/mod/semver"
 
-	"github.com/Masterminds/semver/v3"
 	"github.com/pulumi/upgrade-provider/colorize"
 	"github.com/pulumi/upgrade-provider/step"
 )
@@ -143,7 +143,7 @@ func UpgradeProvider(ctx context.Context, repoOrg, repoName string) error {
 	if GetContext(ctx).UpgradeBridgeVersion {
 		discoverSteps = append(discoverSteps,
 			step.F("Planning Bridge Update", func(context.Context) (string, error) {
-				switch v := ctx.TargetBridgeRef.(type) {
+				switch v := GetContext(ctx).TargetBridgeRef.(type) {
 				case nil:
 					return "", fmt.Errorf("--target-bridge-version is required here")
 				case *HashReference:
@@ -152,7 +152,7 @@ func UpgradeProvider(ctx context.Context, repoOrg, repoName string) error {
 					// If our target upgrade version is the same as our
 					// current version, we skip the update.
 					if v.String() == goMod.Bridge.Version {
-						ctx.UpgradeBridgeVersion = false
+						GetContext(ctx).UpgradeBridgeVersion = false
 						return fmt.Sprintf("Up to date at %s", v.String()), nil
 					}
 
@@ -230,11 +230,11 @@ func UpgradeProvider(ctx context.Context, repoOrg, repoName string) error {
 					GetContext(ctx).UpgradePfVersion = false
 					return "Unused", nil
 				}
-				switch ctx.TargetBridgeRef.(type) {
+				switch GetContext(ctx).TargetBridgeRef.(type) {
 				case *HashReference:
 					// if --target-bridge-version has specified a hash
 					// reference, use that reference for pf code as well
-					targetPfVersion = ctx.TargetBridgeRef
+					targetPfVersion = GetContext(ctx).TargetBridgeRef
 				default:
 					// in all other cases, compute the latest pf tag
 					refs, err := gitRefsOf(ctx, "https://"+modPathWithoutVersion(goMod.Bridge.Path),

--- a/upgrade/util.go
+++ b/upgrade/util.go
@@ -28,8 +28,10 @@ type Context struct {
 	InferVersion  bool
 
 	UpgradeBridgeVersion bool
-	UpgradeSdkVersion    bool
-	UpgradePfVersion     bool
+	TargetBridgeRef      Ref
+
+	UpgradeSdkVersion bool
+	UpgradePfVersion  bool
 
 	UpgradeProviderVersion bool
 	MajorVersionBump       bool

--- a/upgrade/versions.go
+++ b/upgrade/versions.go
@@ -1,0 +1,55 @@
+package upgrade
+
+import (
+	"fmt"
+
+	"github.com/Masterminds/semver/v3"
+)
+
+type Ref interface {
+	refish()
+	String() string
+}
+
+type Version struct {
+	SemVer *semver.Version
+}
+
+func (*Version) refish() {}
+
+func (x *Version) String() string {
+	return x.SemVer.String()
+}
+
+type HashReference struct {
+	GitHash string
+}
+
+func (*HashReference) refish() {}
+
+func (x *HashReference) String() string {
+	return x.GitHash
+}
+
+type Latest struct{}
+
+func (*Latest) refish() {}
+
+func (x *Latest) String() string {
+	return "<latest>"
+}
+
+func ParseRef(s string) (Ref, error) {
+	if s == "" {
+		return nil, fmt.Errorf("empty string is not a valid version")
+	}
+	if s == "latest" {
+		return &Latest{}, nil
+	}
+	v, err := semver.NewVersion(s)
+	if err == nil {
+		return &Version{v}, nil
+	}
+	// assume this is a hash reference otherwise
+	return &HashReference{s}, nil
+}

--- a/upgrade/versions.go
+++ b/upgrade/versions.go
@@ -7,8 +7,8 @@ import (
 )
 
 type Ref interface {
+	fmt.Stringer
 	refish()
-	String() string
 }
 
 type Version struct {


### PR DESCRIPTION
Toward https://github.com/pulumi/pulumi-terraform-bridge/issues/1166

How this was tested:

```
cd ~/code/pulumi-aiven
upgrade-provider --kind bridge pulumi/pulumi-aiven --target-bridge-version $(cd ~/code/pulumi-terraform-bridge && git rev-parse origin/master)
```

What I need this for: I would like to build proper downstream checks in pulumi/pulumi-terraform-bridge that stand up PRs in Tier1 + select Tier2 providers to try out a given bridge version and see if it passes all the tests. It seemed natural to be able to use upgrade-provider as part of that automation to upgrade the provider under test to a given pre-release hash of the bridge being tested.

This is not tracking /pf module yet, perhaps it should in the case of hashes...

- [x] find a way to not ask for reviews from Luke and providers team on experimental PRs with pre-release bridge
- [x] figure out whether pre-release bridge versions should also update matching pf module while that still exists