### PR TITLE
Fix version for latest bridge

### DIFF
--- a/upgrade/versions.go
+++ b/upgrade/versions.go
@@ -18,7 +18,7 @@ type Version struct {
 func (*Version) refish() {}
 
 func (x *Version) String() string {
-	return x.SemVer.String()
+	return x.SemVer.Original()
 }
 
 type HashReference struct {


### PR DESCRIPTION
We try to `go get ...bridge@${SEMVER_VERSION}`, but it should be `go get
...bridge@v${SEMVER_VERSION}`.