### PR TITLE
Rewrite inform GitHub

### DIFF
--- a/step/v2/util.go
+++ b/step/v2/util.go
@@ -54,3 +54,19 @@ func HaltOnError(ctx context.Context, err error) {
 		return err
 	})(ctx)
 }
+
+// Run `f` in `dir`.
+//
+// If the dir does not exist, then the current pipeline will fail.
+func WithCwd(ctx context.Context, dir string, f func(context.Context)) {
+	c := &Cwd{To: dir}
+	err := c.Enter(ctx, StepInfo{})
+	HaltOnError(ctx, err)
+
+	defer func() {
+		err := c.Exit(ctx, nil)
+		HaltOnError(ctx, err)
+	}()
+
+	f(WithEnv(ctx, c))
+}

--- a/step/v2/util_test.go
+++ b/step/v2/util_test.go
@@ -1,0 +1,27 @@
+package step_test
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/pulumi/upgrade-provider/step/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestWithCwd(t *testing.T) {
+	dir := t.TempDir()
+	err := os.WriteFile(filepath.Join(dir, "text.txt"), []byte("abc"), 0600)
+	require.NoError(t, err)
+	err = step.Pipeline("test", func(ctx context.Context) {
+		step.WithCwd(ctx, dir, func(ctx context.Context) {
+			f, err := os.ReadFile("text.txt")
+			require.NoError(t, err)
+			assert.Equal(t, f, []byte("abc"))
+		})
+	})
+
+	assert.NoError(t, err)
+}

--- a/upgrade/steps.go
+++ b/upgrade/steps.go
@@ -20,23 +20,19 @@ import (
 	"gopkg.in/yaml.v3"
 
 	"github.com/pulumi/upgrade-provider/step"
+	stepv2 "github.com/pulumi/upgrade-provider/step/v2"
 )
 
 // A "git commit" step that is resilient to no changes in the directory.
-// ß
+//
 // This is required to accommodate failure and retry in the `git` push steps.
-func GitCommit(ctx context.Context, msg string) step.Step {
-	return step.Computed(func() step.Step {
-		check, err := exec.CommandContext(ctx, "git", "status", "--porcelain=1").CombinedOutput()
-		description := fmt.Sprintf(`git commit -m "%s"`, msg)
-		if err != nil {
-			return step.Error("git commit", err)
-		}
-		if len(check) > 0 {
-			return step.Cmd("git", "commit", "-m", msg)
-		}
-		return step.Value(description, "nothing to commit")
-	})
+func gitCommit(ctx context.Context, msg string) {
+	status := stepv2.Cmd(ctx, "git", "status", "--porcelain=1")
+	if len(status) > 0 {
+		stepv2.Cmd(ctx, "git", "commit", "-m", msg)
+	} else {
+		stepv2.SetLabel(ctx, msg+": nothing to commit")
+	}
 }
 
 // Upgrade the upstream fork of a pulumi provider.
@@ -307,9 +303,11 @@ func UpgradeProviderVersion(
 func InformGitHub(
 	ctx context.Context, target *UpstreamUpgradeTarget, repo ProviderRepo,
 	goMod *GoMod, targetBridgeVersion, targetPfVersion Ref, tfSDKUpgrade string,
-) step.Step {
-	pushBranch := step.Cmd("git", "push", "--set-upstream",
-		"origin", repo.workingBranch).In(&repo.root)
+	osArgs []string,
+) error {
+	ctx = stepv2.WithEnv(ctx, &stepv2.Cwd{To: repo.root})
+
+	stepv2.Cmd(ctx, "git", "push", "--set-upstream", "origin", repo.workingBranch)
 
 	var prTitle string
 	if ctx := GetContext(ctx); ctx.UpgradeProviderVersion {
@@ -324,38 +322,32 @@ func InformGitHub(
 	} else if ctx.UpgradeSdkVersion {
 		prTitle = "Upgrade Pulumi SDK dependency"
 	} else {
-		panic("Unknown action")
+		return fmt.Errorf("Unknown action")
 	}
 
-	createPR := step.Cmd("gh", "pr", "create",
+	stepv2.Cmd(ctx, "gh", "pr", "create",
 		"--assignee", GetContext(ctx).PrAssign,
 		"--base", repo.defaultBranch,
 		"--head", repo.workingBranch,
 		"--reviewer", GetContext(ctx).PrReviewers,
 		"--title", prTitle,
-		"--body", prBody(ctx, repo, target, goMod, targetBridgeVersion, tfSDKUpgrade, os.Args),
-	).In(&repo.root)
-	return step.Combined("GitHub",
-		pushBranch,
-		createPR,
-		step.Computed(func() step.Step {
-			// If we are only upgrading the bridge, we wont have a list of
-			// issues.
-			if !GetContext(ctx).UpgradeProviderVersion {
-				return nil
-			}
+		"--body", prBody(ctx, repo, target, goMod, targetBridgeVersion, tfSDKUpgrade, osArgs))
 
-			// This PR will close issues, so we assign the issues same assignee as
-			// the PR itself.
-			issues := make([]step.Step, len(target.GHIssues))
-			for i, t := range target.GHIssues {
-				issues[i] = step.Cmd(
-					"gh", "issue", "edit", fmt.Sprintf("%d", t.Number),
-					"--add-assignee", GetContext(ctx).PrAssign).In(&repo.root)
-			}
-			return step.Combined("Assign Issues", issues...)
-		}),
-	)
+	// If we are only upgrading the bridge, we wont have a list of issues.
+	if !GetContext(ctx).UpgradeProviderVersion {
+		return nil
+	}
+
+	stepv2.Call00(ctx, "Assign Issues", func(ctx context.Context) {
+		// This PR will close issues, so we assign the issues same assignee as the
+		// PR itself.
+		for _, t := range target.GHIssues {
+			stepv2.Cmd(ctx, "gh", "issue", "edit", fmt.Sprintf("%d", t.Number),
+				"--add-assignee", GetContext(ctx).PrAssign)
+		}
+	})
+
+	return nil
 }
 
 // Most if not all of our TF SDK based providers use a "replace" based version of
@@ -699,6 +691,20 @@ func UpdateFileWithSignal(desc, path string, didChange *bool, f func([]byte) ([]
 		}
 		*didChange = true
 		return "", os.WriteFile(path, newBytes, stats.Mode().Perm())
+	})
+}
+
+func UpdateFileV2(ctx context.Context, path string, update func(context.Context, string) string) bool {
+	return stepv2.Call01(ctx, "Update "+path, func(ctx context.Context) bool {
+		content := stepv2.ReadFile(ctx, path)
+		updated := stepv2.Call11(ctx, "update", update, content)
+		if content == updated {
+			stepv2.SetLabel(ctx, "No change")
+			return false
+		}
+
+		stepv2.WriteFile(ctx, path, updated)
+		return true
 	})
 }
 

--- a/upgrade/testdata/replay/wavefront-inform-github.json
+++ b/upgrade/testdata/replay/wavefront-inform-github.json
@@ -1,0 +1,118 @@
+{
+  "pipelines": [
+    {
+      "name": "Tfgen & Build SDKs",
+      "steps": [
+        {
+          "name": "Inform Github",
+          "inputs": [
+            {
+              "Version": "5.0.5",
+              "GHIssues": [
+                {
+                  "number": 232
+                }
+              ]
+            },
+            {},
+            {
+              "Kind": "plain",
+              "Upstream": {
+                "Path": "github.com/vmware/terraform-provider-wavefront",
+                "Version": "v0.0.0-20231006183745-aa9a262f8bb0"
+              },
+              "Fork": null,
+              "Bridge": {
+                "Path": "github.com/pulumi/pulumi-terraform-bridge/v3",
+                "Version": "v3.61.0"
+              },
+              "Pf": {
+                "Path": ""
+              },
+              "UpstreamProviderOrg": "vmware"
+            },
+            null,
+            null,
+            "Up to date at 2.29.0",
+            [
+              "upgrade-provider",
+              "pulumi/pulumi-wavefront"
+            ]
+          ],
+          "outputs": [
+            null
+          ]
+        },
+        {
+          "name": "git",
+          "inputs": [
+            "git",
+            [
+              "push",
+              "--set-upstream",
+              "origin",
+              "upgrade-terraform-provider-wavefront-to-v5.0.5"
+            ]
+          ],
+          "outputs": [
+            "branch 'upgrade-terraform-provider-wavefront-to-v5.0.5' set up to track 'origin/upgrade-terraform-provider-wavefront-to-v5.0.5'.\n",
+            null
+          ],
+          "impure": true
+        },
+        {
+          "name": "gh",
+          "inputs": [
+            "gh",
+            [
+              "pr",
+              "create",
+              "--assignee",
+              "@me",
+              "--base",
+              "master",
+              "--head",
+              "upgrade-terraform-provider-wavefront-to-v5.0.5",
+              "--reviewer",
+              "pulumi/Providers,lukehoban",
+              "--title",
+              "Upgrade terraform-provider-wavefront to v5.0.5",
+              "--body",
+              "This PR was generated via `$ upgrade-provider pulumi/pulumi-wavefront`.\n\n---\n\n- Upgrading terraform-provider-wavefront from 5.0.3  to 5.0.5.\n\tFixes #232\n"
+            ]
+          ],
+          "outputs": [
+            "https://github.com/pulumi/pulumi-wavefront/pull/239\n",
+            null
+          ],
+          "impure": true
+        },
+        {
+          "name": "Assign Issues",
+          "inputs": [],
+          "outputs": [
+            null
+          ]
+        },
+        {
+          "name": "gh",
+          "inputs": [
+            "gh",
+            [
+              "issue",
+              "edit",
+              "232",
+              "--add-assignee",
+              "@me"
+            ]
+          ],
+          "outputs": [
+            "https://github.com/pulumi/pulumi-wavefront/issues/232\n",
+            null
+          ],
+          "impure": true
+        }
+      ]
+    }
+  ]
+}

--- a/upgrade/upgrade-provider.go
+++ b/upgrade/upgrade-provider.go
@@ -469,7 +469,7 @@ func tfgenAndBuildSDKs(
 		stepv2.Cmd(root, "make", "tfgen")
 
 		stepv2.Cmd(root, "git", "add", "--all")
-		stepv2.Call10(ctx, "Tfgen", gitCommit, "make tfgen")
+		gitCommit(ctx, "make tfgen")
 
 		stepv2.Cmd(root, "make", "build_sdks")
 
@@ -491,9 +491,9 @@ func tfgenAndBuildSDKs(
 
 		stepv2.Cmd(root, "git", "add", "--all")
 
-		stepv2.Call10(ctx, "Build SDKs", gitCommit, "make build_sdks")
+		gitCommit(ctx, "make build_sdks")
 
-		stepv2.Call70E(ctx, "Inform Github", InformGitHub,
-			upgradeTarget, repo, goMod, targetBridgeVersion, targetPfVersion, tfSDKUpgrade, os.Args)
+		InformGitHub(ctx, upgradeTarget, repo, goMod, targetBridgeVersion,
+			targetPfVersion, tfSDKUpgrade, os.Args)
 	}
 }

--- a/upgrade/upgrade-provider.go
+++ b/upgrade/upgrade-provider.go
@@ -1,11 +1,11 @@
 package upgrade
 
 import (
-	"bytes"
 	"context"
 	"errors"
 	"fmt"
-	"path/filepath"
+	"io"
+	"os"
 	"sort"
 	"strings"
 
@@ -16,6 +16,7 @@ import (
 
 	"github.com/pulumi/upgrade-provider/colorize"
 	"github.com/pulumi/upgrade-provider/step"
+	stepv2 "github.com/pulumi/upgrade-provider/step/v2"
 )
 
 type CodeMigration = func(ctx context.Context, repo ProviderRepo) (step.Step, error)
@@ -25,8 +26,15 @@ var CodeMigrations = map[string]CodeMigration{
 	"assertnoerror": ReplaceAssertNoError,
 }
 
-func UpgradeProvider(ctx context.Context, repoOrg, repoName string) error {
-	var err error
+func UpgradeProvider(ctx context.Context, repoOrg, repoName string) (err error) {
+
+	// Setup ctx to enable replay tests with stepv2:
+	if file := os.Getenv("PULUMI_REPLAY"); file != "" {
+		var write io.Closer
+		ctx, write = stepv2.WithRecord(ctx, file)
+		defer func() { err = errors.Join(err, write.Close()) }()
+	}
+
 	repo := ProviderRepo{
 		name: repoName,
 		org:  repoOrg,
@@ -433,52 +441,59 @@ func UpgradeProvider(ctx context.Context, repoOrg, repoName string) error {
 		}
 	}
 
-	artifacts := append(steps,
-		step.Cmd("go", "mod", "tidy").In(repo.providerDir()),
-		step.Cmd("go", "mod", "tidy").In(repo.examplesDir()),
-		step.Cmd("go", "mod", "tidy").In(repo.sdkDir()),
-		step.Computed(func() step.Step {
-			if GetContext(ctx).RemovePlugins {
-				return step.Cmd("pulumi", "plugin", "rm", "--all", "--yes")
-			}
-			return nil
-		}),
-		step.Cmd("make", "tfgen").In(&repo.root),
-		step.Cmd("git", "add", "--all").In(&repo.root),
-		GitCommit(ctx, "make tfgen").In(&repo.root),
-		step.Cmd("make", "build_sdks").In(&repo.root),
-		step.Computed(func() step.Step {
-			if !GetContext(ctx).MajorVersionBump {
-				return nil
-			}
+	ok = step.Run(ctx, step.Combined("Update Repository", steps...))
+	if !ok {
+		return ErrHandled
+	}
 
-			return UpdateFile("Update module in sdk/go.mod", "sdk/go.mod", func(b []byte) ([]byte, error) {
+	return stepv2.PipelineCtx(ctx, "Tfgen & Build SDKs",
+		tfgenAndBuildSDKs(repo, repoName, upgradeTarget, goMod,
+			targetBridgeVersion, targetPfVersion, tfSDKUpgrade))
+}
+
+func tfgenAndBuildSDKs(
+	repo ProviderRepo, repoName string, upgradeTarget *UpstreamUpgradeTarget, goMod *GoMod,
+	targetBridgeVersion, targetPfVersion Ref, tfSDKUpgrade string,
+) func(ctx context.Context) {
+	return func(ctx context.Context) {
+		env := func(path string) context.Context { return stepv2.WithEnv(ctx, &stepv2.Cwd{To: path}) }
+		root := env(repo.root)
+		stepv2.Cmd(env(*repo.providerDir()), "go", "mod", "tidy")
+		stepv2.Cmd(env(*repo.examplesDir()), "go", "mod", "tidy")
+		stepv2.Cmd(env(*repo.sdkDir()), "go", "mod", "tidy")
+
+		if GetContext(ctx).RemovePlugins {
+			stepv2.Cmd(ctx, "pulumi", "plugin", "rm", "--all", "--yes")
+		}
+
+		stepv2.Cmd(root, "make", "tfgen")
+
+		stepv2.Cmd(root, "git", "add", "--all")
+		stepv2.Call10(ctx, "Tfgen", gitCommit, "make tfgen")
+
+		stepv2.Cmd(root, "make", "build_sdks")
+
+		// Update sdk/go.mod's module after rebuilding the go SDK
+		if GetContext(ctx).MajorVersionBump {
+			update := func(_ context.Context, s string) string {
 				base := "module github.com/" + repoName + "/sdk"
 				old := base
 				if repo.currentVersion.Major() > 1 {
 					old += fmt.Sprintf("/v%d", repo.currentVersion.Major())
 				}
 				new := base + fmt.Sprintf("/v%d", repo.currentVersion.Major()+1)
-				return bytes.ReplaceAll(b, []byte(old), []byte(new)), nil
-			}).In(&repo.root)
-		}),
-		step.Computed(func() step.Step {
-			if !GetContext(ctx).MajorVersionBump {
-				return nil
+				return strings.ReplaceAll(s, old, new)
 			}
-			dir := filepath.Join(repo.root, "sdk")
-			return step.Cmd("go", "mod", "tidy").
-				In(&dir)
-		}),
-		step.Cmd("git", "add", "--all").In(&repo.root),
-		GitCommit(ctx, "make build_sdks").In(&repo.root),
-		InformGitHub(ctx, upgradeTarget, repo, goMod, targetBridgeVersion, targetPfVersion, tfSDKUpgrade),
-	)
+			UpdateFileV2(root, "sdk/go.mod", update)
 
-	ok = step.Run(ctx, step.Combined("Update Artifacts", artifacts...))
-	if !ok {
-		return ErrHandled
+			stepv2.Cmd(env(*repo.sdkDir()), "go", "mod", "tidy")
+		}
+
+		stepv2.Cmd(root, "git", "add", "--all")
+
+		stepv2.Call10(ctx, "Build SDKs", gitCommit, "make build_sdks")
+
+		stepv2.Call70E(ctx, "Inform Github", InformGitHub,
+			upgradeTarget, repo, goMod, targetBridgeVersion, targetPfVersion, tfSDKUpgrade, os.Args)
 	}
-
-	return nil
 }

--- a/upgrade/upgrade_test.go
+++ b/upgrade/upgrade_test.go
@@ -1,0 +1,134 @@
+package upgrade
+
+import (
+	"context"
+	"testing"
+
+	"github.com/Masterminds/semver/v3"
+	"github.com/pulumi/upgrade-provider/step/v2"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/mod/module"
+)
+
+func TestInformGithub(t *testing.T) {
+	replay := step.NewReplay(t, []byte(`{
+        "pipelines": [
+            {
+                "name": "Tfgen & Build SDKs",
+                "steps": [
+                    {
+                        "name": "Inform Github",
+                        "inputs": [
+                            {
+                                "Version": "5.0.5",
+                                "GHIssues": [
+                                    {
+                                        "number": 232
+                                    }
+                                ]
+                            },
+                            {},
+                            {
+                                "Kind": "plain",
+                                "Upstream": {
+                                    "Path": "github.com/vmware/terraform-provider-wavefront",
+                                    "Version": "v0.0.0-20231006183745-aa9a262f8bb0"
+                                },
+                                "Fork": null,
+                                "Bridge": {
+                                    "Path": "github.com/pulumi/pulumi-terraform-bridge/v3",
+                                    "Version": "v3.61.0"
+                                },
+                                "Pf": {
+                                    "Path": ""
+                                },
+                                "UpstreamProviderOrg": "vmware"
+                            },
+                            null,
+                            null,
+                            "Up to date at 2.29.0",
+                            ["upgrade-provider", "pulumi/pulumi-wavefront"]
+                        ],
+                        "outputs": [
+                            null
+                        ]
+                    },
+                    {
+                        "name": "git",
+                        "inputs": [
+                            "/opt/homebrew/bin/git push --set-upstream origin upgrade-terraform-provider-wavefront-to-v5.0.5"
+                        ],
+                        "outputs": [
+                            "branch 'upgrade-terraform-provider-wavefront-to-v5.0.5' set up to track 'origin/upgrade-terraform-provider-wavefront-to-v5.0.5'.\n",
+                            null
+                        ],
+                        "impure": true
+                    },
+                    {
+                        "name": "gh",
+    "inputs": [
+      "/opt/homebrew/bin/gh pr create --assignee @me --base master --head upgrade-terraform-provider-wavefront-to-v5.0.5 --reviewer pulumi/Providers,lukehoban --title Upgrade terraform-provider-wavefront to v5.0.5 --body This PR was generated via `+"`$ upgrade-provider pulumi/pulumi-wavefront`"+`.\n\n---\n\n- Upgrading terraform-provider-wavefront from 5.0.3  to 5.0.5.\n\tFixes #232\n"
+    ],
+    "outputs": [
+      "https://github.com/pulumi/pulumi-wavefront/pull/239\n",
+      null
+    ],
+    "impure": true
+  },
+  {
+    "name": "Assign Issues",
+    "inputs": [],
+    "outputs": [
+      null
+    ]
+  },
+  {
+    "name": "gh",
+    "inputs": [
+      "/opt/homebrew/bin/gh issue edit 232 --add-assignee @me"
+    ],
+    "outputs": [
+      "https://github.com/pulumi/pulumi-wavefront/issues/232\n",
+      null
+    ],
+    "impure": true
+  }
+]
+}
+]
+}`))
+
+	ctx := (&Context{
+		UpgradeProviderVersion: true,
+		PrAssign:               "@me",
+		PrReviewers:            "pulumi/Providers,lukehoban",
+		UpstreamProviderName:   "terraform-provider-wavefront",
+	}).Wrap(context.Background())
+
+	err := step.PipelineCtx(step.WithEnv(ctx, replay), "Tfgen & Build SDKs", func(ctx context.Context) {
+		step.Call70E(ctx, "Inform Github", InformGitHub,
+			&UpstreamUpgradeTarget{
+				GHIssues: []UpgradeTargetIssue{
+					{Number: 232},
+				},
+				Version: semver.MustParse("5.0.5"),
+			}, ProviderRepo{
+				workingBranch:          "upgrade-terraform-provider-wavefront-to-v5.0.5",
+				defaultBranch:          "master",
+				name:                   "pulumi/pulumi-wavefront",
+				currentUpstreamVersion: semver.MustParse("5.0.3"),
+			}, &GoMod{
+				UpstreamProviderOrg: "vmware",
+				Kind:                "plain",
+				Upstream: module.Version{
+					Path:    "github.com/vmware/terraform-provider-wavefront",
+					Version: "v0.0.0-20231006183745-aa9a262f8bb0",
+				},
+				Bridge: module.Version{
+					Path:    "github.com/pulumi/pulumi-terraform-bridge/v3",
+					Version: "v3.61.0",
+				},
+			}, nil, nil, "Up to date at 2.29.0", []string{"upgrade-provider", "pulumi/pulumi-wavefront"})
+	})
+	require.NoError(t, err)
+}

--- a/upgrade/upgrade_test.go
+++ b/upgrade/upgrade_test.go
@@ -2,6 +2,8 @@ package upgrade
 
 import (
 	"context"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/Masterminds/semver/v3"
@@ -11,101 +13,16 @@ import (
 )
 
 func TestInformGithub(t *testing.T) {
-	replay := step.NewReplay(t, []byte(`{
-        "pipelines": [
-            {
-                "name": "Tfgen & Build SDKs",
-                "steps": [
-                    {
-                        "name": "Inform Github",
-                        "inputs": [
-                            {
-                                "Version": "5.0.5",
-                                "GHIssues": [
-                                    {
-                                        "number": 232
-                                    }
-                                ]
-                            },
-                            {},
-                            {
-                                "Kind": "plain",
-                                "Upstream": {
-                                    "Path": "github.com/vmware/terraform-provider-wavefront",
-                                    "Version": "v0.0.0-20231006183745-aa9a262f8bb0"
-                                },
-                                "Fork": null,
-                                "Bridge": {
-                                    "Path": "github.com/pulumi/pulumi-terraform-bridge/v3",
-                                    "Version": "v3.61.0"
-                                },
-                                "Pf": {
-                                    "Path": ""
-                                },
-                                "UpstreamProviderOrg": "vmware"
-                            },
-                            null,
-                            null,
-                            "Up to date at 2.29.0",
-                            ["upgrade-provider", "pulumi/pulumi-wavefront"]
-                        ],
-                        "outputs": [
-                            null
-                        ]
-                    },
-                    {
-                        "name": "git",
-                        "inputs": [
-                            "git",  ["push", "--set-upstream", "origin", "upgrade-terraform-provider-wavefront-to-v5.0.5"]
-                        ],
-                        "outputs": [
-                            "branch 'upgrade-terraform-provider-wavefront-to-v5.0.5' set up to track 'origin/upgrade-terraform-provider-wavefront-to-v5.0.5'.\n",
-                            null
-                        ],
-                        "impure": true
-                    },
-                    {
-                        "name": "gh",
-    "inputs": [
-      "gh",  ["pr", "create", "--assignee", "@me", "--base", "master", "--head", "upgrade-terraform-provider-wavefront-to-v5.0.5", "--reviewer", "pulumi/Providers,lukehoban", "--title", "Upgrade terraform-provider-wavefront to v5.0.5", "--body", "This PR was generated via `+"`$ upgrade-provider pulumi/pulumi-wavefront`"+`.\n\n---\n\n- Upgrading terraform-provider-wavefront from 5.0.3  to 5.0.5.\n\tFixes #232\n"]
-    ],
-    "outputs": [
-      "https://github.com/pulumi/pulumi-wavefront/pull/239\n",
-      null
-    ],
-    "impure": true
-  },
-  {
-    "name": "Assign Issues",
-    "inputs": [],
-    "outputs": [
-      null
-    ]
-  },
-  {
-    "name": "gh",
-    "inputs": [
-      "gh", ["issue", "edit", "232", "--add-assignee", "@me"]
-    ],
-    "outputs": [
-      "https://github.com/pulumi/pulumi-wavefront/issues/232\n",
-      null
-    ],
-    "impure": true
-  }
-]
-}
-]
-}`))
+	ctx := newReplay(t, "wavefront-inform-github")
 
-	ctx := (&Context{
+	ctx = (&Context{
 		UpgradeProviderVersion: true,
 		PrAssign:               "@me",
 		PrReviewers:            "pulumi/Providers,lukehoban",
 		UpstreamProviderName:   "terraform-provider-wavefront",
-	}).Wrap(context.Background())
+	}).Wrap(ctx)
 
-	err := step.PipelineCtx(step.WithEnv(ctx, replay), "Tfgen & Build SDKs", func(ctx context.Context) {
+	err := step.PipelineCtx(ctx, "Tfgen & Build SDKs", func(ctx context.Context) {
 		step.Call70E(ctx, "Inform Github", InformGitHub,
 			&UpstreamUpgradeTarget{
 				GHIssues: []UpgradeTargetIssue{
@@ -131,4 +48,18 @@ func TestInformGithub(t *testing.T) {
 			}, nil, nil, "Up to date at 2.29.0", []string{"upgrade-provider", "pulumi/pulumi-wavefront"})
 	})
 	require.NoError(t, err)
+}
+
+func newReplay(t *testing.T, name string) context.Context {
+	ctx := context.Background()
+	path := filepath.Join("testdata", "replay", name+".json")
+	bytes := readFile(t, path)
+	r := step.NewReplay(t, bytes)
+	return step.WithEnv(ctx, r)
+}
+
+func readFile(t *testing.T, path string) []byte {
+	bytes, err := os.ReadFile(path)
+	require.NoError(t, err)
+	return bytes
 }

--- a/upgrade/upgrade_test.go
+++ b/upgrade/upgrade_test.go
@@ -56,7 +56,7 @@ func TestInformGithub(t *testing.T) {
                     {
                         "name": "git",
                         "inputs": [
-                            "/opt/homebrew/bin/git push --set-upstream origin upgrade-terraform-provider-wavefront-to-v5.0.5"
+                            "git",  ["push", "--set-upstream", "origin", "upgrade-terraform-provider-wavefront-to-v5.0.5"]
                         ],
                         "outputs": [
                             "branch 'upgrade-terraform-provider-wavefront-to-v5.0.5' set up to track 'origin/upgrade-terraform-provider-wavefront-to-v5.0.5'.\n",
@@ -67,7 +67,7 @@ func TestInformGithub(t *testing.T) {
                     {
                         "name": "gh",
     "inputs": [
-      "/opt/homebrew/bin/gh pr create --assignee @me --base master --head upgrade-terraform-provider-wavefront-to-v5.0.5 --reviewer pulumi/Providers,lukehoban --title Upgrade terraform-provider-wavefront to v5.0.5 --body This PR was generated via `+"`$ upgrade-provider pulumi/pulumi-wavefront`"+`.\n\n---\n\n- Upgrading terraform-provider-wavefront from 5.0.3  to 5.0.5.\n\tFixes #232\n"
+      "gh",  ["pr", "create", "--assignee", "@me", "--base", "master", "--head", "upgrade-terraform-provider-wavefront-to-v5.0.5", "--reviewer", "pulumi/Providers,lukehoban", "--title", "Upgrade terraform-provider-wavefront to v5.0.5", "--body", "This PR was generated via `+"`$ upgrade-provider pulumi/pulumi-wavefront`"+`.\n\n---\n\n- Upgrading terraform-provider-wavefront from 5.0.3  to 5.0.5.\n\tFixes #232\n"]
     ],
     "outputs": [
       "https://github.com/pulumi/pulumi-wavefront/pull/239\n",
@@ -85,7 +85,7 @@ func TestInformGithub(t *testing.T) {
   {
     "name": "gh",
     "inputs": [
-      "/opt/homebrew/bin/gh issue edit 232 --add-assignee @me"
+      "gh", ["issue", "edit", "232", "--add-assignee", "@me"]
     ],
     "outputs": [
       "https://github.com/pulumi/pulumi-wavefront/issues/232\n",

--- a/upgrade/upgrade_test.go
+++ b/upgrade/upgrade_test.go
@@ -23,7 +23,7 @@ func TestInformGithub(t *testing.T) {
 	}).Wrap(ctx)
 
 	err := step.PipelineCtx(ctx, "Tfgen & Build SDKs", func(ctx context.Context) {
-		step.Call70E(ctx, "Inform Github", InformGitHub,
+		InformGitHub(ctx,
 			&UpstreamUpgradeTarget{
 				GHIssues: []UpgradeTargetIssue{
 					{Number: 232},


### PR DESCRIPTION
This PR rewrites the final section of the upgrade provider tool to use the `step/v2` library. Rewriting in `step/v2` has multiple benefits:

- Unlike `step` or the tool itself, `step/v2` was built with testing in mind: I have included a replay test for `InformGitHub` that asserts that if `InformGitHub` is called with the described inputs, it will call the correct set of shell commands with the correct set of arguments.

- `step/v2` is synchronous and strongly typed. Calling a step to read a file looks like this:
  https://github.com/pulumi/upgrade-provider/blob/da557c51f6c45f5468894c13c6aa35e684471aad/upgrade/steps.go#L699
  `content` is then just a string. It doesn't need special handling and you can read it immediately.

For a stronger description of the difference between `step` and `step/v2`, please see https://github.com/pulumi/upgrade-provider/pull/181.