### PR TITLE
Disable PF upgrade when /pf is not found, not UpgradeProviderVersion

### DIFF
--- a/upgrade/kind.go
+++ b/upgrade/kind.go
@@ -104,9 +104,11 @@ func GetRepoKind(ctx context.Context, repo ProviderRepo) (*GoMod, error) {
 	pf, ok, err := originalGoVersionOf(ctx, repo, filepath.Join("provider", "go.mod"), "github.com/pulumi/pulumi-terraform-bridge/pf")
 	if err != nil {
 		return nil, err
-	}
-	if ctx := GetContext(ctx); !ok && ctx.UpgradeProviderVersion {
-		setFalse(&ctx.UpgradeProviderVersion)
+	} else if !ok {
+		// If we successfully opened provider/go.mod but didn't find any reference
+		// to "github.com/pulumi/pulumi-terraform-bridge/pf", we assume that the
+		// provider doesn't use /pf and it doesn't make sense to upgrade.
+		setFalse(&GetContext(ctx).UpgradePfVersion)
 	}
 
 	tfProviderRepoName := GetContext(ctx).UpstreamProviderName

--- a/upgrade/kind.go
+++ b/upgrade/kind.go
@@ -108,7 +108,7 @@ func GetRepoKind(ctx context.Context, repo ProviderRepo) (*GoMod, error) {
 		// If we successfully opened provider/go.mod but didn't find any reference
 		// to "github.com/pulumi/pulumi-terraform-bridge/pf", we assume that the
 		// provider doesn't use /pf and it doesn't make sense to upgrade.
-		setFalse(&GetContext(ctx).UpgradePfVersion)
+		GetContext(ctx).UpgradePfVersion = false
 	}
 
 	tfProviderRepoName := GetContext(ctx).UpstreamProviderName
@@ -213,8 +213,4 @@ func GetRepoKind(ctx context.Context, repo ProviderRepo) (*GoMod, error) {
 	}
 
 	return &out, nil
-}
-
-func setFalse(b *bool) {
-	*b = false
 }


### PR DESCRIPTION
This regression was introduced in https://github.com/pulumi/upgrade-provider/pull/174. Before #174, `Context` was passed by value, and calling `setFalse` didn't do anything. I believe that code was always broken, but since it mutated a copy it was harmless.

This is a priority fix, since our automation is currently broken for providers that don't use /pf.

Fixes #179