### PR TITLE
Handle repeated upgrades (with branch conflicts)

### DIFF
--- a/upgrade/steps_test.go
+++ b/upgrade/steps_test.go
@@ -1,0 +1,194 @@
+package upgrade
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/Masterminds/semver/v3"
+	"github.com/pulumi/upgrade-provider/step/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetWorkingBranch(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		c                                    Context
+		targetBridgeVersion, targetPfVersion Ref
+		upgradeTarget                        UpstreamUpgradeTarget
+
+		expected    string
+		expectedErr string
+	}{
+		{
+			c: Context{
+				UpgradeProviderVersion: true,
+				UpstreamProviderName:   "foo",
+			},
+			upgradeTarget: UpstreamUpgradeTarget{Version: semver.MustParse("1.2.3")},
+			expected:      "upgrade-foo-to-v1.2.3",
+		},
+		{
+			c: Context{
+				UpgradeBridgeVersion: true,
+				TargetBridgeRef:      &Version{SemVer: semver.MustParse("v1.2.3")},
+			},
+			targetBridgeVersion: &Version{SemVer: semver.MustParse("1.2.3")},
+			expected:            "upgrade-pulumi-terraform-bridge-to-1.2.3",
+		},
+		{expectedErr: "unknown action"}, // If no action can be produced, we should error.
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run("", func(t *testing.T) {
+			t.Parallel()
+
+			err := step.Pipeline(t.Name(), func(ctx context.Context) {
+				actual := getWorkingBranch(ctx, tt.c, tt.targetBridgeVersion, tt.targetPfVersion, &tt.upgradeTarget)
+				assert.Equal(t, tt.expected, actual)
+			})
+
+			if tt.expectedErr == "" {
+				assert.NoError(t, err)
+			} else {
+				assert.ErrorContains(t, err, tt.expectedErr)
+			}
+		})
+	}
+}
+
+func TestHasRemoteBranch(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		responce   string
+		branchName string
+		expect     bool
+	}{
+		{
+			responce:   `[{"headRefName":"dependabot/go_modules/provider/golang.org/x/net-0.17.0","title":"Bump golang.org/x/net from 0.13.0 to 0.17.0 in /provider"},{"headRefName":"dependabot/go_modules/sdk/golang.org/x/net-0.17.0","title":"bump golang.org/x/net from 0.10.0 to 0.17.0 in /sdk"},{"headRefName":"dependabot/go_modules/examples/golang.org/x/net-0.17.0","title":"Bump golang.org/x/net from 0.8.0 to 0.17.0 in /examples"}]`,
+			branchName: "upgrade-pulumi-terraform-bridge-to-v3.62.0",
+			expect:     false,
+		},
+		{
+			responce:   `[{"headRefName":"upgrade-pulumi-terraform-bridge-to-v3.62.0","title":"Upgrade pulumi-terraform-bridge to v3.62.0"},{"headRefName":"dependabot/go_modules/provider/golang.org/x/net-0.17.0","title":"Bump golang.org/x/net from 0.13.0 to 0.17.0 in /provider"},{"headRefName":"dependabot/go_modules/sdk/golang.org/x/net-0.17.0","title":"bump golang.org/x/net from 0.10.0 to 0.17.0 in /sdk"},{"headRefName":"dependabot/go_modules/examples/golang.org/x/net-0.17.0","title":"Bump golang.org/x/net from 0.8.0 to 0.17.0 in /examples"}]`,
+			branchName: "upgrade-pulumi-terraform-bridge-to-v3.62.0",
+			expect:     true,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run("", func(t *testing.T) {
+			t.Parallel()
+
+			encode := func(elem any) json.RawMessage {
+				b, err := json.Marshal(elem)
+				require.NoError(t, err)
+				return json.RawMessage(b)
+			}
+
+			simpleReplay(t, step.RecordV1{
+				Name: t.Name(),
+				Steps: []*step.Step{
+					{
+						Name:    "Has Remote Branch",
+						Inputs:  encode([]string{tt.branchName}),
+						Outputs: encode([]any{tt.expect, nil}),
+					},
+					{
+						Name: "gh",
+						Inputs: encode([]any{
+							"gh", []string{"pr", "list", "--json=title,headRefName"},
+						}),
+						Outputs: encode([]any{tt.responce, nil}),
+						Impure:  true,
+					},
+				},
+			}, func(ctx context.Context) { hasRemoteBranch(ctx, tt.branchName) })
+		})
+	}
+}
+
+func TestEnsureBranchCheckedOut(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		responce   string
+		branchName string
+		call       []string
+		namedValue string
+	}{
+		{
+			responce:   "* master\n",
+			branchName: "upgrade-pulumi-terraform-bridge-to-v3.62.0",
+			namedValue: "",
+			call:       []string{"checkout", "-b", "upgrade-pulumi-terraform-bridge-to-v3.62.0"},
+		},
+		{
+			responce:   "* master\n  upgrade-pulumi-terraform-bridge-to-v3.62.0\n",
+			branchName: "upgrade-pulumi-terraform-bridge-to-v3.62.0",
+			namedValue: "already exists",
+			call:       []string{"checkout", "upgrade-pulumi-terraform-bridge-to-v3.62.0"},
+		},
+		{
+			responce:   "  master\n* upgrade-pulumi-terraform-bridge-to-v3.62.0\n",
+			branchName: "upgrade-pulumi-terraform-bridge-to-v3.62.0",
+			namedValue: "already current",
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run("", func(t *testing.T) {
+			t.Parallel()
+
+			encode := func(elem any) json.RawMessage {
+				b, err := json.Marshal(elem)
+				require.NoError(t, err)
+				return json.RawMessage(b)
+			}
+
+			replay := step.RecordV1{
+				Name: t.Name(),
+				Steps: []*step.Step{
+					{
+						Name:    "Ensure Branch",
+						Inputs:  encode([]string{tt.branchName}),
+						Outputs: encode([]any{nil}),
+					},
+					{
+						Name: "git",
+						Inputs: encode([]any{
+							"git", []string{"branch"},
+						}),
+						Outputs: encode([]any{tt.responce, nil}),
+						Impure:  true,
+					},
+					{
+						Name:    tt.namedValue,
+						Inputs:  encode([]any{}),
+						Outputs: encode([]any{true, nil}),
+					},
+					{
+						Name:    "git",
+						Inputs:  encode([]any{"git", tt.call}),
+						Outputs: encode([]any{"", nil}),
+						Impure:  true,
+					},
+				},
+			}
+
+			if tt.namedValue == "" {
+				replay.Steps = append(replay.Steps[:2], replay.Steps[3:]...)
+			}
+			if len(tt.call) == 0 {
+				replay.Steps = replay.Steps[:len(replay.Steps)-1]
+			}
+
+			simpleReplay(t, replay, func(ctx context.Context) {
+				ensureBranchCheckedOut(ctx, tt.branchName)
+			})
+		})
+	}
+}

--- a/upgrade/steps_test.go
+++ b/upgrade/steps_test.go
@@ -62,17 +62,17 @@ func TestGetWorkingBranch(t *testing.T) {
 func TestHasRemoteBranch(t *testing.T) {
 	t.Parallel()
 	tests := []struct {
-		responce   string
+		response   string
 		branchName string
 		expect     bool
 	}{
 		{
-			responce:   `[{"headRefName":"dependabot/go_modules/provider/golang.org/x/net-0.17.0","title":"Bump golang.org/x/net from 0.13.0 to 0.17.0 in /provider"},{"headRefName":"dependabot/go_modules/sdk/golang.org/x/net-0.17.0","title":"bump golang.org/x/net from 0.10.0 to 0.17.0 in /sdk"},{"headRefName":"dependabot/go_modules/examples/golang.org/x/net-0.17.0","title":"Bump golang.org/x/net from 0.8.0 to 0.17.0 in /examples"}]`,
+			response:   `[{"headRefName":"dependabot/go_modules/provider/golang.org/x/net-0.17.0","title":"Bump golang.org/x/net from 0.13.0 to 0.17.0 in /provider"},{"headRefName":"dependabot/go_modules/sdk/golang.org/x/net-0.17.0","title":"bump golang.org/x/net from 0.10.0 to 0.17.0 in /sdk"},{"headRefName":"dependabot/go_modules/examples/golang.org/x/net-0.17.0","title":"Bump golang.org/x/net from 0.8.0 to 0.17.0 in /examples"}]`,
 			branchName: "upgrade-pulumi-terraform-bridge-to-v3.62.0",
 			expect:     false,
 		},
 		{
-			responce:   `[{"headRefName":"upgrade-pulumi-terraform-bridge-to-v3.62.0","title":"Upgrade pulumi-terraform-bridge to v3.62.0"},{"headRefName":"dependabot/go_modules/provider/golang.org/x/net-0.17.0","title":"Bump golang.org/x/net from 0.13.0 to 0.17.0 in /provider"},{"headRefName":"dependabot/go_modules/sdk/golang.org/x/net-0.17.0","title":"bump golang.org/x/net from 0.10.0 to 0.17.0 in /sdk"},{"headRefName":"dependabot/go_modules/examples/golang.org/x/net-0.17.0","title":"Bump golang.org/x/net from 0.8.0 to 0.17.0 in /examples"}]`,
+			response:   `[{"headRefName":"upgrade-pulumi-terraform-bridge-to-v3.62.0","title":"Upgrade pulumi-terraform-bridge to v3.62.0"},{"headRefName":"dependabot/go_modules/provider/golang.org/x/net-0.17.0","title":"Bump golang.org/x/net from 0.13.0 to 0.17.0 in /provider"},{"headRefName":"dependabot/go_modules/sdk/golang.org/x/net-0.17.0","title":"bump golang.org/x/net from 0.10.0 to 0.17.0 in /sdk"},{"headRefName":"dependabot/go_modules/examples/golang.org/x/net-0.17.0","title":"Bump golang.org/x/net from 0.8.0 to 0.17.0 in /examples"}]`,
 			branchName: "upgrade-pulumi-terraform-bridge-to-v3.62.0",
 			expect:     true,
 		},
@@ -102,7 +102,7 @@ func TestHasRemoteBranch(t *testing.T) {
 						Inputs: encode([]any{
 							"gh", []string{"pr", "list", "--json=title,headRefName"},
 						}),
-						Outputs: encode([]any{tt.responce, nil}),
+						Outputs: encode([]any{tt.response, nil}),
 						Impure:  true,
 					},
 				},
@@ -114,25 +114,25 @@ func TestHasRemoteBranch(t *testing.T) {
 func TestEnsureBranchCheckedOut(t *testing.T) {
 	t.Parallel()
 	tests := []struct {
-		responce   string
+		response   string
 		branchName string
 		call       []string
 		namedValue string
 	}{
 		{
-			responce:   "* master\n",
+			response:   "* master\n",
 			branchName: "upgrade-pulumi-terraform-bridge-to-v3.62.0",
 			namedValue: "",
 			call:       []string{"checkout", "-b", "upgrade-pulumi-terraform-bridge-to-v3.62.0"},
 		},
 		{
-			responce:   "* master\n  upgrade-pulumi-terraform-bridge-to-v3.62.0\n",
+			response:   "* master\n  upgrade-pulumi-terraform-bridge-to-v3.62.0\n",
 			branchName: "upgrade-pulumi-terraform-bridge-to-v3.62.0",
 			namedValue: "already exists",
 			call:       []string{"checkout", "upgrade-pulumi-terraform-bridge-to-v3.62.0"},
 		},
 		{
-			responce:   "  master\n* upgrade-pulumi-terraform-bridge-to-v3.62.0\n",
+			response:   "  master\n* upgrade-pulumi-terraform-bridge-to-v3.62.0\n",
 			branchName: "upgrade-pulumi-terraform-bridge-to-v3.62.0",
 			namedValue: "already current",
 		},
@@ -162,7 +162,7 @@ func TestEnsureBranchCheckedOut(t *testing.T) {
 						Inputs: encode([]any{
 							"git", []string{"branch"},
 						}),
-						Outputs: encode([]any{tt.responce, nil}),
+						Outputs: encode([]any{tt.response, nil}),
 						Impure:  true,
 					},
 					{

--- a/upgrade/testdata/replay/kong_existing_pr.json
+++ b/upgrade/testdata/replay/kong_existing_pr.json
@@ -1,0 +1,188 @@
+{
+  "pipelines": [
+    {
+      "name": "Setup working branch",
+      "steps": [
+        {
+          "name": "Working Branch Name",
+          "inputs": [
+            {
+              "GoPath": "/Users/ianwahbe/go",
+              "TargetVersion": null,
+              "InferVersion": true,
+              "UpgradeBridgeVersion": true,
+              "TargetBridgeRef": {},
+              "UpgradeSdkVersion": false,
+              "UpgradePfVersion": false,
+              "UpgradeProviderVersion": false,
+              "MajorVersionBump": false,
+              "UpstreamProviderName": "terraform-provider-kong",
+              "JavaVersion": "",
+              "UpgradeCodeMigration": false,
+              "MigrationOpts": null,
+              "AllowMissingDocs": false,
+              "RemovePlugins": true,
+              "PrReviewers": "pulumi/Providers,lukehoban",
+              "PrAssign": "@me",
+              "CreateFailureIssue": false,
+              "PRDescription": ""
+            },
+            {
+              "SemVer": "3.62.0"
+            },
+            null,
+            null
+          ],
+          "outputs": [
+            "upgrade-pulumi-terraform-bridge-to-v3.62.0",
+            null
+          ]
+        },
+        {
+          "name": "Ensure Branch",
+          "inputs": [
+            "upgrade-pulumi-terraform-bridge-to-v3.62.0"
+          ],
+          "outputs": [
+            null
+          ]
+        },
+        {
+          "name": "git",
+          "inputs": [
+            "git",
+            [
+              "branch"
+            ]
+          ],
+          "outputs": [
+            "* master\n",
+            null
+          ],
+          "impure": true
+        },
+        {
+          "name": "git",
+          "inputs": [
+            "git",
+            [
+              "checkout",
+              "-b",
+              "upgrade-pulumi-terraform-bridge-to-v3.62.0"
+            ]
+          ],
+          "outputs": [
+            "",
+            null
+          ],
+          "impure": true
+        },
+        {
+          "name": "Has Remote Branch",
+          "inputs": [
+            "upgrade-pulumi-terraform-bridge-to-v3.62.0"
+          ],
+          "outputs": [
+            true,
+            null
+          ]
+        },
+        {
+          "name": "gh",
+          "inputs": [
+            "gh",
+            [
+              "pr",
+              "list",
+              "--json=title,headRefName"
+            ]
+          ],
+          "outputs": [
+            "[{\"headRefName\":\"upgrade-pulumi-terraform-bridge-to-v3.62.0\",\"title\":\"Upgrade pulumi-terraform-bridge to v3.62.0\"},{\"headRefName\":\"dependabot/go_modules/provider/golang.org/x/net-0.17.0\",\"title\":\"Bump golang.org/x/net from 0.13.0 to 0.17.0 in /provider\"},{\"headRefName\":\"dependabot/go_modules/sdk/golang.org/x/net-0.17.0\",\"title\":\"bump golang.org/x/net from 0.10.0 to 0.17.0 in /sdk\"},{\"headRefName\":\"dependabot/go_modules/examples/golang.org/x/net-0.17.0\",\"title\":\"Bump golang.org/x/net from 0.8.0 to 0.17.0 in /examples\"}]\n",
+            null
+          ],
+          "impure": true
+        }
+      ]
+    },
+    {
+      "name": "Tfgen \u0026 Build SDKs",
+      "steps": [
+        {
+          "name": "Inform Github",
+          "inputs": [
+            null,
+            {},
+            {
+              "Kind": "plain",
+              "Upstream": {
+                "Path": "github.com/kevholditch/terraform-provider-kong",
+                "Version": "v1.9.2-0.20220328204855-9e50bd93437f"
+              },
+              "Fork": null,
+              "Bridge": {
+                "Path": "github.com/pulumi/pulumi-terraform-bridge/v3",
+                "Version": "v3.60.0"
+              },
+              "Pf": {
+                "Path": ""
+              },
+              "UpstreamProviderOrg": "kevholditch"
+            },
+            {
+              "SemVer": "3.62.0"
+            },
+            null,
+            "Up to date at 2.29.0",
+            [
+              "upgrade-provider",
+              "pulumi/pulumi-kong",
+              "--kind=bridge"
+            ]
+          ],
+          "outputs": [
+            null
+          ]
+        },
+        {
+          "name": "git",
+          "inputs": [
+            "git",
+            [
+              "push",
+              "--set-upstream",
+              "origin",
+              "upgrade-pulumi-terraform-bridge-to-v3.62.0",
+              "--force"
+            ]
+          ],
+          "outputs": [
+            "branch 'upgrade-pulumi-terraform-bridge-to-v3.62.0' set up to track 'origin/upgrade-pulumi-terraform-bridge-to-v3.62.0'.\n",
+            null
+          ],
+          "impure": true
+        },
+        {
+          "name": "gh",
+          "inputs": [
+            "gh",
+            [
+              "pr",
+              "edit",
+              "upgrade-pulumi-terraform-bridge-to-v3.62.0",
+              "--title",
+              "Upgrade pulumi-terraform-bridge to v3.62.0",
+              "--body",
+              "This PR was generated via `$ upgrade-provider pulumi/pulumi-kong --kind=bridge`.\n\n---\n\n- Upgrading pulumi-terraform-bridge from v3.60.0 to v3.62.0.\n"
+            ]
+          ],
+          "outputs": [
+            "https://github.com/pulumi/pulumi-kong/pull/228\n",
+            null
+          ],
+          "impure": true
+        }
+      ]
+    }
+  ]
+}

--- a/upgrade/testdata/replay/wavefront_inform_github.json
+++ b/upgrade/testdata/replay/wavefront_inform_github.json
@@ -51,7 +51,8 @@
               "push",
               "--set-upstream",
               "origin",
-              "upgrade-terraform-provider-wavefront-to-v5.0.5"
+              "upgrade-terraform-provider-wavefront-to-v5.0.5",
+              "--force"
             ]
           ],
           "outputs": [

--- a/upgrade/upgrade_provider.go
+++ b/upgrade/upgrade_provider.go
@@ -323,6 +323,7 @@ func UpgradeProvider(ctx context.Context, repoOrg, repoName string) (err error) 
 	err = stepv2.PipelineCtx(ctx, "Setup working branch", func(ctx context.Context) {
 		repo.workingBranch = getWorkingBranch(ctx, *GetContext(ctx), targetBridgeVersion, targetPfVersion, upgradeTarget)
 		ensureBranchCheckedOut(ctx, repo.workingBranch)
+		repo.prAlreadyExists = hasRemoteBranch(ctx, repo.workingBranch)
 	})
 	if err != nil {
 		return err

--- a/upgrade/upgrade_provider.go
+++ b/upgrade/upgrade_provider.go
@@ -320,26 +320,15 @@ func UpgradeProvider(ctx context.Context, repoOrg, repoName string) (err error) 
 	}
 
 	var targetSHA string
-	if ctx := GetContext(ctx); ctx.UpgradeProviderVersion {
-		repo.workingBranch = fmt.Sprintf("upgrade-%s-to-v%s",
-			ctx.UpstreamProviderName, upgradeTarget.Version)
-	} else if ctx.UpgradeBridgeVersion {
-		contract.Assertf(targetBridgeVersion != nil,
-			"We are upgrading the bridge, so we must have a target version")
-		repo.workingBranch = fmt.Sprintf("upgrade-pulumi-terraform-bridge-to-%s",
-			targetBridgeVersion)
-	} else if ctx.UpgradeCodeMigration {
-		repo.workingBranch = "upgrade-code-migration"
-	} else if ctx.UpgradePfVersion {
-		repo.workingBranch = fmt.Sprintf("upgrade-pf-version-to-%s", targetPfVersion)
-	} else if ctx.UpgradeSdkVersion {
-		repo.workingBranch = "upgrade-pulumi-sdk"
-	} else {
-		return fmt.Errorf("calculating branch name: unknown action")
+	err = stepv2.PipelineCtx(ctx, "Setup working branch", func(ctx context.Context) {
+		repo.workingBranch = getWorkingBranch(ctx, *GetContext(ctx), targetBridgeVersion, targetPfVersion, upgradeTarget)
+		ensureBranchCheckedOut(ctx, repo.workingBranch)
+	})
+	if err != nil {
+		return err
 	}
-	steps := []step.Step{
-		EnsureBranchCheckedOut(ctx, repo.workingBranch).In(&repo.root),
-	}
+
+	var steps []step.Step
 
 	if GetContext(ctx).MajorVersionBump {
 		steps = append(steps, MajorVersionBump(ctx, goMod, upgradeTarget, repo))

--- a/upgrade/util.go
+++ b/upgrade/util.go
@@ -84,6 +84,8 @@ type ProviderRepo struct {
 	defaultBranch string
 	// The working branch of the repository
 	workingBranch string
+	// If there is already a PR on GitHub who is merging from `repo.workingBranch`.
+	prAlreadyExists bool
 
 	// The highest version tag released on the repo
 	currentVersion *semver.Version


### PR DESCRIPTION
Fixes #160 

This PR makes the tool work correctly when there is an existing remote branch of the same name. If there is an existing PR, it will have its body edited so it is up to date.

I have tested on the `pulumi-kong` provider, then turned the resulting replay into unit tests.

---

Downstream issues:
Fixes https://github.com/pulumi/pulumi-kong/issues/225
Fixes https://github.com/pulumi/pulumi-keycloak/issues/289
Fixes https://github.com/pulumi/pulumi-ec/issues/166
Fixes https://github.com/pulumi/pulumi-docker/issues/800