### PR TITLE
Keep the sdk version inline with the bridge

### DIFF
--- a/main.go
+++ b/main.go
@@ -131,18 +131,6 @@ func cmd() *cobra.Command {
 					if experimental {
 						context.UpgradeCodeMigration = true
 					}
-
-					if len(upgradeKind) > 1 {
-						for _, v := range upgradeKind {
-							if v == "sdk" {
-								context.UpgradeSdkVersion = true
-							}
-						}
-						if !context.UpgradeSdkVersion {
-							warnedAll = true
-							warn("`--kind=all` implies all of bridge,provider,code options")
-						}
-					}
 				case "bridge":
 					set(&context.UpgradeBridgeVersion)
 					set(&context.UpgradePfVersion)
@@ -150,8 +138,6 @@ func cmd() *cobra.Command {
 					set(&context.UpgradeProviderVersion)
 				case "code":
 					set(&context.UpgradeCodeMigration)
-				case "sdk":
-					set(&context.UpgradeSdkVersion)
 				case "pf":
 					set(&context.UpgradePfVersion)
 				default:

--- a/upgrade/steps.go
+++ b/upgrade/steps.go
@@ -326,8 +326,6 @@ var InformGitHub = stepv2.Func70E("Inform Github", func(
 		prTitle = fmt.Sprintf("Code migration: %s", strings.Join(ctx.MigrationOpts, ", "))
 	} else if ctx.UpgradePfVersion {
 		prTitle = "Upgrade pulumi-terraform-bridge/pf to " + targetPfVersion.String()
-	} else if ctx.UpgradeSdkVersion {
-		prTitle = "Upgrade Pulumi SDK dependency"
 	} else {
 		return fmt.Errorf("Unknown action")
 	}
@@ -466,8 +464,6 @@ var getWorkingBranch = stepv2.Func41E("Working Branch Name", func(ctx context.Co
 		return ret("upgrade-code-migration")
 	case c.UpgradePfVersion:
 		return ret(fmt.Sprintf("upgrade-pf-version-to-%s", targetPfVersion))
-	case c.UpgradeSdkVersion:
-		return ret("upgrade-pulumi-sdk")
 	default:
 		return "", fmt.Errorf("calculating branch name: unknown action")
 	}

--- a/upgrade/steps_helpers.go
+++ b/upgrade/steps_helpers.go
@@ -163,9 +163,6 @@ func prBody(ctx context.Context, repo ProviderRepo,
 			goMod.Pf.Version, targetPf)
 	}
 
-	if GetContext(ctx).UpgradeSdkVersion {
-		fmt.Fprintf(b, "- Upgrading pulumi SDK to `latest`.\n")
-	}
 	if parts := strings.Split(tfSDKUpgrade, " -> "); len(parts) == 2 {
 		fmt.Fprintf(b, "- Upgrading pulumi/terraform-plugin-sdk from %s to %s.\n",
 			parts[0], parts[1])

--- a/upgrade/upgrade_provider.go
+++ b/upgrade/upgrade_provider.go
@@ -295,7 +295,7 @@ func UpgradeProvider(ctx context.Context, repoOrg, repoName string) (err error) 
 	// Running the discover steps might have invalidated one or more actions. If there
 	// are no actions remaining, we can exit early.
 	if ctx := GetContext(ctx); !ctx.UpgradeBridgeVersion && !ctx.UpgradeProviderVersion &&
-		!ctx.UpgradeCodeMigration && !ctx.UpgradeSdkVersion && !ctx.UpgradePfVersion {
+		!ctx.UpgradeCodeMigration && !ctx.UpgradePfVersion {
 		fmt.Println(colorize.Bold("No actions needed"))
 		return nil
 	}
@@ -384,18 +384,6 @@ func UpgradeProvider(ctx context.Context, repoOrg, repoName string) (err error) 
 		upgradePulumiEverywhereStep := BridgePulumiVersions(ctx, repo)
 
 		steps = append(steps, upgradePulumiEverywhereStep)
-
-	}
-	if GetContext(ctx).UpgradeSdkVersion {
-		steps = append(steps, step.Combined("Upgrade Pulumi SDK",
-			step.Cmd("go", "get", "github.com/pulumi/pulumi/sdk/v3").
-				In(repo.providerDir()),
-			step.Cmd("go", "get", "github.com/pulumi/pulumi/pkg/v3").
-				In(repo.providerDir())),
-			step.Cmd("go", "get", "github.com/pulumi/pulumi/sdk/v3").
-				In(repo.examplesDir()),
-			step.Cmd("go", "get", "github.com/pulumi/pulumi/pkg/v3").
-				In(repo.examplesDir()))
 	}
 	if GetContext(ctx).UpgradePfVersion {
 		steps = append(steps, step.Cmd("go", "get",

--- a/upgrade/util.go
+++ b/upgrade/util.go
@@ -30,8 +30,7 @@ type Context struct {
 	UpgradeBridgeVersion bool
 	TargetBridgeRef      Ref
 
-	UpgradeSdkVersion bool
-	UpgradePfVersion  bool
+	UpgradePfVersion bool
 
 	UpgradeProviderVersion bool
 	MajorVersionBump       bool


### PR DESCRIPTION
This removes the `--kind=sdk` option from the tool.

We already have functionality to bring the pkg+sdk version in all places up to what the bridge requires.

Fixes #184