### PR TITLE
Normalize bridge ref parsing

### DIFF
--- a/main.go
+++ b/main.go
@@ -32,7 +32,6 @@ const (
 
 func cmd() *cobra.Command {
 	var targetVersion string
-	var targetBridgeRef string
 
 	gopath, ok := os.LookupEnv("GOPATH")
 	if !ok {
@@ -99,14 +98,6 @@ func cmd() *cobra.Command {
 				if err != nil {
 					return fmt.Errorf("--target-version=%s: %w",
 						targetVersion, err)
-				}
-			}
-
-			if targetBridgeRef != "" {
-				context.TargetBridgeRef, err = upgrade.ParseRef(targetBridgeRef)
-				if err != nil {
-					return fmt.Errorf("--target-bridge-version=%s: %w",
-						targetBridgeRef, err)
 				}
 			}
 
@@ -239,7 +230,8 @@ This is equivalent to setting PULUMI_MISSING_DOCS_ERROR=${! VALUE}.`)
 	cmd.PersistentFlags().StringVar(&context.JavaVersion, "java-version", "",
 		"The version of pulumi-java-gen to target.")
 
-	cmd.PersistentFlags().StringVar(&targetBridgeRef, "target-bridge-version", "latest",
+	context.TargetBridgeRef = &upgrade.Latest{} // Set default
+	cmd.PersistentFlags().VarP(upgrade.RefFlag(&context.TargetBridgeRef), "target-bridge-version", "",
 		`The desired bridge version to upgrade to. Git hash references permitted.`)
 
 	cmd.PersistentFlags().StringVar(&context.PRDescription, "pr-description", "",


### PR DESCRIPTION
Clean up argument parsing for a `Ref` object. This also gets better error messages.