### PR TITLE
Support setting target pulumi version

### DIFF
--- a/main.go
+++ b/main.go
@@ -186,7 +186,7 @@ If the passed version does not exist, an error is signaled.`)
 	cmd.PersistentFlags().VarP(upgrade.RefFlag(&context.TargetPulumiVersion), "target-pulumi-version", "",
 		`Upgrade the provider to the passed pulumi/{pkg,sdk} version.
 
-	If no version is passed, the pulumi/{pkg,sdk} version will track the bridge`)
+If no version is passed, the pulumi/{pkg,sdk} version will track the bridge`)
 
 	cmd.PersistentFlags().BoolVar(&context.InferVersion, "pulumi-infer-version", false,
 		`Use our GH issues to infer the target upgrade version.

--- a/main.go
+++ b/main.go
@@ -183,6 +183,11 @@ func cmd() *cobra.Command {
 
 If the passed version does not exist, an error is signaled.`)
 
+	cmd.PersistentFlags().StringVar(&context.TargetPulumiVersion, "target-pulumi-version", "",
+		`Upgrade the provider to the passed pulumi/{pkg,sdk} version.
+
+If no version is passed, the pulumi/{pkg,sdk} version will track the bridge`)
+
 	cmd.PersistentFlags().BoolVar(&context.InferVersion, "pulumi-infer-version", false,
 		`Use our GH issues to infer the target upgrade version.
 		If both '--target-version' and '--pulumi-infer-version' are passed,

--- a/main.go
+++ b/main.go
@@ -183,10 +183,10 @@ func cmd() *cobra.Command {
 
 If the passed version does not exist, an error is signaled.`)
 
-	cmd.PersistentFlags().StringVar(&context.TargetPulumiVersion, "target-pulumi-version", "",
+	cmd.PersistentFlags().VarP(upgrade.RefFlag(&context.TargetPulumiVersion), "target-pulumi-version", "",
 		`Upgrade the provider to the passed pulumi/{pkg,sdk} version.
 
-If no version is passed, the pulumi/{pkg,sdk} version will track the bridge`)
+	If no version is passed, the pulumi/{pkg,sdk} version will track the bridge`)
 
 	cmd.PersistentFlags().BoolVar(&context.InferVersion, "pulumi-infer-version", false,
 		`Use our GH issues to infer the target upgrade version.

--- a/upgrade/steps.go
+++ b/upgrade/steps.go
@@ -327,8 +327,8 @@ var InformGitHub = stepv2.Func70E("Inform Github", func(
 		prTitle = fmt.Sprintf("Code migration: %s", strings.Join(c.MigrationOpts, ", "))
 	case c.UpgradePfVersion:
 		prTitle = "Upgrade pulumi-terraform-bridge/pf to " + targetPfVersion.String()
-	case c.TargetPulumiVersion != "":
-		prTitle = "Test: Upgrade pulumi/{pkg,sdk} to " + c.TargetPulumiVersion
+	case c.TargetPulumiVersion != nil:
+		prTitle = "Test: Upgrade pulumi/{pkg,sdk} to " + c.TargetPulumiVersion.String()
 	default:
 		return fmt.Errorf("Unknown action")
 	}
@@ -471,7 +471,7 @@ var getWorkingBranch = stepv2.Func41E("Working Branch Name", func(ctx context.Co
 		return ret("upgrade-code-migration")
 	case c.UpgradePfVersion:
 		return ret("upgrade-pf-version-to-%s", targetPfVersion)
-	case c.TargetPulumiVersion != "":
+	case c.TargetPulumiVersion != nil:
 		return ret("upgrade-pulumi-version-to-%s", c.TargetPulumiVersion)
 	default:
 		return "", fmt.Errorf("calculating branch name: unknown action")

--- a/upgrade/upgrade_provider.go
+++ b/upgrade/upgrade_provider.go
@@ -295,7 +295,7 @@ func UpgradeProvider(ctx context.Context, repoOrg, repoName string) (err error) 
 	// Running the discover steps might have invalidated one or more actions. If there
 	// are no actions remaining, we can exit early.
 	if ctx := GetContext(ctx); !ctx.UpgradeBridgeVersion && !ctx.UpgradeProviderVersion &&
-		!ctx.UpgradeCodeMigration && !ctx.UpgradePfVersion {
+		!ctx.UpgradeCodeMigration && !ctx.UpgradePfVersion && ctx.TargetPulumiVersion == "" {
 		fmt.Println(colorize.Bold("No actions needed"))
 		return nil
 	}
@@ -366,29 +366,36 @@ func UpgradeProvider(ctx context.Context, repoOrg, repoName string) (err error) 
 	}
 
 	if GetContext(ctx).UpgradeBridgeVersion {
-		steps = append(steps, step.Cmd("go", "get",
-			"github.com/pulumi/pulumi-terraform-bridge/v3@"+targetBridgeVersion.String()).
-			In(repo.providerDir()))
-
-		steps = append(steps, step.Cmd("go", "get",
-			"github.com/hashicorp/terraform-plugin-framework").
-			In(repo.providerDir()))
-		steps = append(steps, step.Cmd("go", "get",
-			"github.com/hashicorp/terraform-plugin-mux").
-			In(repo.providerDir()))
-		steps = append(steps, step.Cmd("go", "mod", "tidy").
-			In(repo.providerDir()))
-
-		// Now that we've upgraded the bridge, we want the other places in the repo to use the bridge's
-		// Pulumi version.
-		upgradePulumiEverywhereStep := BridgePulumiVersions(ctx, repo)
-
-		steps = append(steps, upgradePulumiEverywhereStep)
+		steps = append(steps, step.Combined("Upgrade Bridge Version",
+			step.Cmd("go", "get",
+				"github.com/pulumi/pulumi-terraform-bridge/v3@"+targetBridgeVersion.String()),
+			step.Cmd("go", "get", "github.com/hashicorp/terraform-plugin-framework"),
+			step.Cmd("go", "get", "github.com/hashicorp/terraform-plugin-mux"),
+			step.Cmd("go", "mod", "tidy"),
+		).In(repo.providerDir()))
 	}
 	if GetContext(ctx).UpgradePfVersion {
-		steps = append(steps, step.Cmd("go", "get",
-			"github.com/pulumi/pulumi-terraform-bridge/pf@"+targetPfVersion.String()).
-			In(repo.providerDir()))
+		steps = append(steps, step.Combined("Upgrade Pf Version",
+			step.Cmd("go", "get",
+				"github.com/pulumi/pulumi-terraform-bridge/pf@"+targetPfVersion.String()),
+			step.Cmd("go", "mod", "tidy"),
+		).In(repo.providerDir()))
+	}
+
+	if v := GetContext(ctx).TargetPulumiVersion; v != "" {
+		steps = append(steps, step.Combined("Upgrade Pulumi Version",
+			step.Cmd("go", "get", "github.com/pulumi/pulumi/pkg/v3@"+v),
+			step.Cmd("go", "get", "github.com/pulumi/pulumi/sdk/v3@"+v),
+			step.Cmd("go", "mod", "tidy"),
+		).In(repo.providerDir()))
+	}
+
+	if GetContext(ctx).UpgradeBridgeVersion ||
+		GetContext(ctx).UpgradePfVersion ||
+		GetContext(ctx).TargetPulumiVersion != "" {
+		// Having changed the version of pulumi/{sdk,pkg} that we are using, we
+		// need to propagate that change to the go.mod in {sdk,examples}/go.mod
+		steps = append(steps, applyPulumiVersion(ctx, repo))
 	}
 
 	if GetContext(ctx).UpgradeCodeMigration {

--- a/upgrade/upgrade_provider.go
+++ b/upgrade/upgrade_provider.go
@@ -295,7 +295,7 @@ func UpgradeProvider(ctx context.Context, repoOrg, repoName string) (err error) 
 	// Running the discover steps might have invalidated one or more actions. If there
 	// are no actions remaining, we can exit early.
 	if ctx := GetContext(ctx); !ctx.UpgradeBridgeVersion && !ctx.UpgradeProviderVersion &&
-		!ctx.UpgradeCodeMigration && !ctx.UpgradePfVersion && ctx.TargetPulumiVersion == "" {
+		!ctx.UpgradeCodeMigration && !ctx.UpgradePfVersion && ctx.TargetPulumiVersion == nil {
 		fmt.Println(colorize.Bold("No actions needed"))
 		return nil
 	}
@@ -382,10 +382,10 @@ func UpgradeProvider(ctx context.Context, repoOrg, repoName string) (err error) 
 		).In(repo.providerDir()))
 	}
 
-	if v := GetContext(ctx).TargetPulumiVersion; v != "" {
+	if ref := GetContext(ctx).TargetPulumiVersion; ref != nil {
 		r := func(kind string) string {
 			mod := "github.com/pulumi/pulumi/" + kind + "/v3"
-			return fmt.Sprintf("%[1]s=%[1]s@%s", mod, v)
+			return fmt.Sprintf("%[1]s=%[1]s@%s", mod, ref)
 
 		}
 
@@ -404,7 +404,7 @@ func UpgradeProvider(ctx context.Context, repoOrg, repoName string) (err error) 
 	}
 
 	if (GetContext(ctx).UpgradeBridgeVersion || GetContext(ctx).UpgradePfVersion) &&
-		GetContext(ctx).TargetPulumiVersion == "" {
+		GetContext(ctx).TargetPulumiVersion == nil {
 		// Having changed the version of pulumi/{sdk,pkg} that we are using, we
 		// need to propagate that change to the go.mod in {sdk,examples}/go.mod
 		//

--- a/upgrade/util.go
+++ b/upgrade/util.go
@@ -48,7 +48,7 @@ type Context struct {
 	// If TargetPulumiVersion is nil, then pulumi/{pkg,sdk} should follow the bridge.
 	//
 	// Otherwise, we will `replace` with TargetPulumiVersion for both pkg and sdk.
-	TargetPulumiVersion string
+	TargetPulumiVersion Ref
 
 	// The desired java version.
 	JavaVersion string

--- a/upgrade/util.go
+++ b/upgrade/util.go
@@ -43,6 +43,13 @@ type Context struct {
 	//
 	UpstreamProviderName string
 
+	// The desired version of pulumi/{pkg,sdk} to link to.
+	//
+	// If TargetPulumiVersion is nil, then pulumi/{pkg,sdk} should follow the bridge.
+	//
+	// Otherwise, we will `require` the described version.
+	TargetPulumiVersion string
+
 	// The desired java version.
 	JavaVersion string
 	// The old java version we found.

--- a/upgrade/util.go
+++ b/upgrade/util.go
@@ -47,7 +47,7 @@ type Context struct {
 	//
 	// If TargetPulumiVersion is nil, then pulumi/{pkg,sdk} should follow the bridge.
 	//
-	// Otherwise, we will `require` the described version.
+	// Otherwise, we will `replace` with TargetPulumiVersion for both pkg and sdk.
 	TargetPulumiVersion string
 
 	// The desired java version.

--- a/upgrade/versions.go
+++ b/upgrade/versions.go
@@ -60,10 +60,9 @@ func RefFlag(r *Ref) pflag.Value { return &refFlag{r} }
 type refFlag struct{ r *Ref }
 
 func (f *refFlag) String() string {
-	if f == nil || f.r == nil && *f.r == nil {
+	if f == nil || f.r == nil || *f.r == nil {
 		return ""
 	}
-
 	return (*f.r).String()
 }
 

--- a/upgrade/versions.go
+++ b/upgrade/versions.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/Masterminds/semver/v3"
+	"github.com/spf13/pflag"
 )
 
 type Ref interface {
@@ -53,3 +54,25 @@ func ParseRef(s string) (Ref, error) {
 	// assume this is a hash reference otherwise
 	return &HashReference{s}, nil
 }
+
+func RefFlag(r *Ref) pflag.Value { return &refFlag{r} }
+
+type refFlag struct{ r *Ref }
+
+func (f *refFlag) String() string {
+	if f == nil || f.r == nil && *f.r == nil {
+		return ""
+	}
+
+	return (*f.r).String()
+}
+
+func (f *refFlag) Set(s string) error {
+	r, err := ParseRef(s)
+	if err == nil {
+		*f.r = r
+	}
+	return err
+}
+
+func (*refFlag) Type() string { return "ref" }


### PR DESCRIPTION
Adds a --target-pulumi-version flag to support pre-testing upgrades of pulumi/pkg and pulumi/sdk. 

End-to-end tested through ci-mgmt etc in https://github.com/pulumi/pulumi-aiven/actions/runs/6671310230/job/18132952860 