### PR TITLE
Prepare upstream upgrades for release

### DIFF
--- a/upgrade/steps.go
+++ b/upgrade/steps.go
@@ -325,6 +325,7 @@ var InformGitHub = stepv2.Func70E("Inform Github", func(
 	}
 
 	prBody := prBody(ctx, repo, target, goMod, targetBridgeVersion, targetPfVersion, tfSDKUpgrade, osArgs)
+
 	if repo.prAlreadyExists {
 		// Update the description in case anything else was upgraded (or not
 		// upgraded) in this run, compared to the existing PR.
@@ -332,13 +333,26 @@ var InformGitHub = stepv2.Func70E("Inform Github", func(
 			"--title", prTitle,
 			"--body", prBody)
 	} else {
-		stepv2.Cmd(ctx, "gh", "pr", "create",
-			"--assignee", c.PrAssign,
-			"--base", repo.defaultBranch,
-			"--head", repo.workingBranch,
-			"--reviewer", c.PrReviewers,
-			"--title", prTitle,
-			"--body", prBody)
+		addLabels := []string{}
+		// We only create release labels when we are running the full pulumi
+		// providers process: i.e. when we discovered issues to close at the
+		// beginning of the pipeline.
+		if c.UpgradeProviderVersion && len(target.GHIssues) > 0 {
+			label := upgradeLabel(ctx, repo.currentUpstreamVersion, target.Version)
+			if label != "" {
+				addLabels = []string{"--label", label}
+			}
+		}
+
+		stepv2.Cmd(ctx, "gh",
+			append([]string{"pr", "create",
+				"--assignee", c.PrAssign,
+				"--base", repo.defaultBranch,
+				"--head", repo.workingBranch,
+				"--reviewer", c.PrReviewers,
+				"--title", prTitle,
+				"--body", prBody},
+				addLabels...)...)
 	}
 
 	// If we are only upgrading the bridge, we wont have a list of issues.
@@ -356,6 +370,23 @@ var InformGitHub = stepv2.Func70E("Inform Github", func(
 	})(ctx)
 
 	return nil
+})
+
+var upgradeLabel = stepv2.Func21("Release Label", func(ctx context.Context, to, from *semver.Version) string {
+	if to == nil || from == nil {
+		return ""
+	}
+	r := func(s string) string { return "needs-release/" + s }
+	switch {
+	case to.Major() != from.Major():
+		return r("major")
+	case to.Minor() != from.Minor():
+		return r("minor")
+	case to.Patch() != from.Patch():
+		return r("patch")
+	default:
+		return ""
+	}
 })
 
 // Most if not all of our TF SDK based providers use a "replace" based version of

--- a/upgrade/testdata/replay/wavefront_inform_github.json
+++ b/upgrade/testdata/replay/wavefront_inform_github.json
@@ -62,6 +62,17 @@
           "impure": true
         },
         {
+          "name": "Release Label",
+          "inputs": [
+            "5.0.3",
+            "5.0.5"
+          ],
+          "outputs": [
+            "needs-release/patch",
+            null
+          ]
+        },
+        {
           "name": "gh",
           "inputs": [
             "gh",
@@ -79,7 +90,9 @@
               "--title",
               "Upgrade terraform-provider-wavefront to v5.0.5",
               "--body",
-              "This PR was generated via `$ upgrade-provider pulumi/pulumi-wavefront`.\n\n---\n\n- Upgrading terraform-provider-wavefront from 5.0.3  to 5.0.5.\n\tFixes #232\n"
+              "This PR was generated via `$ upgrade-provider pulumi/pulumi-wavefront`.\n\n---\n\n- Upgrading terraform-provider-wavefront from 5.0.3  to 5.0.5.\n\tFixes #232\n",
+              "--label",
+              "needs-release/patch"
             ]
           ],
           "outputs": [


### PR DESCRIPTION
When we upgrade providers, we always increment the version semver version v${major}.${minor}.${patch} by one. We don't always have the same version as the upstream provider, but we almost always mirror the increment they went with. That is:

If they bumped ${major}, then we will also bump ${major}. If they bumped ${minor}, then we will also bump ${minor}. If they bumped ${patch}, then we will also bump ${patch}.

This is communicated to our automation by adding a label to the PR, which is read during the release. The `upgrade-provider` tool has enough information to apply these labels, so it should do so.

This gets us to 1-click provider upgrades.