### PR TITLE
Adds a nix flake

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1699596684,
+        "narHash": "sha256-XSXP8zjBZJBVvpNb2WmY0eW8O2ce+sVyj1T0/iBRIvg=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "da4024d0ead5d7820f6bd15147d3fe2a0c0cec73",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-23.05",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,28 @@
+{
+  description = "A flake defining upgrade-provider build-from-source package";
+
+  inputs = {
+    nixpkgs.url = github:NixOS/nixpkgs/nixos-23.05;
+  };
+
+  outputs = { self, nixpkgs }: let
+
+    package = { system }: let
+      pkgs = import nixpkgs { system = system; };
+    in pkgs.buildGo120Module rec {
+      name = "upgrade-provider";
+      version = ''${self.rev or "dirty"}'';
+      src = ./.;
+      # subPackages = [ "cmd/pulumictl" ];
+      doCheck = false;
+      vendorSha256 = "sha256-YBteVgcWvIE10ojd9W4grMK8kJ0zXXQiBuEHto3sABI=";
+      ldflags = [];
+    };
+
+  in {
+    packages.aarch64-darwin.default = package {  system = "aarch64-darwin"; };
+    packages.aarch64-linux.default = package {  system = "aarch64-linux"; };
+    packages.x86_64-darwin.default = package { system = "x86_64-darwin"; };
+    packages.x86_64-linux.default = package { system = "x86_64-linux"; };
+  };
+}


### PR DESCRIPTION
This enables a new installation method such as:

```
 devbox global add github:pulumi/upgrade-provider/t0yv0/flakes   
```