### PR TITLE
Convert up to target version discover to v2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/pulumi/upgrade-provider
 
-go 1.19
+go 1.21
 
 require (
 	github.com/Masterminds/semver/v3 v3.2.0

--- a/upgrade/steps.go
+++ b/upgrade/steps.go
@@ -893,7 +893,11 @@ func applyPulumiVersion(ctx context.Context, repo ProviderRepo) step.Step {
 		goGet("pkg").In(repo.examplesDir()))
 }
 
-var planProviderUpgrade = stepv2.Func41E("Planning Provider Update", func(ctx context.Context,
+// Plan the update for a provider.
+//
+// That means figuring out the old and the new version, and producing a
+// UpstreamUpgradeTarget.
+var planProviderUpgrade = stepv2.Func41E("Plan Provider Upgrade", func(ctx context.Context,
 	repoOrg, repoName string, goMod *GoMod, repo *ProviderRepo) (*UpstreamUpgradeTarget, error) {
 	upgradeTarget := getExpectedTarget(ctx, repoOrg+"/"+repoName,
 		goMod.UpstreamProviderOrg)
@@ -903,7 +907,6 @@ var planProviderUpgrade = stepv2.Func41E("Planning Provider Update", func(ctx co
 
 	// If we don't have any upgrades to target, assume that we don't need to upgrade.
 	if upgradeTarget.Version == nil {
-		// Otherwise, we don't bother to try to upgrade the provider.
 		GetContext(ctx).UpgradeProviderVersion = false
 		GetContext(ctx).MajorVersionBump = false
 		stepv2.SetLabel(ctx, "Up to date")

--- a/upgrade/steps_test.go
+++ b/upgrade/steps_test.go
@@ -90,22 +90,19 @@ func TestHasRemoteBranch(t *testing.T) {
 				return json.RawMessage(b)
 			}
 
-			simpleReplay(t, step.RecordV1{
-				Name: t.Name(),
-				Steps: []*step.Step{
-					{
-						Name:    "Has Remote Branch",
-						Inputs:  encode([]string{tt.branchName}),
-						Outputs: encode([]any{tt.expect, nil}),
-					},
-					{
-						Name: "gh",
-						Inputs: encode([]any{
-							"gh", []string{"pr", "list", "--json=title,headRefName"},
-						}),
-						Outputs: encode([]any{tt.response, nil}),
-						Impure:  true,
-					},
+			simpleReplay(t, []*step.Step{
+				{
+					Name:    "Has Remote Branch",
+					Inputs:  encode([]string{tt.branchName}),
+					Outputs: encode([]any{tt.expect, nil}),
+				},
+				{
+					Name: "gh",
+					Inputs: encode([]any{
+						"gh", []string{"pr", "list", "--json=title,headRefName"},
+					}),
+					Outputs: encode([]any{tt.response, nil}),
+					Impure:  true,
 				},
 			}, func(ctx context.Context) { hasRemoteBranch(ctx, tt.branchName) })
 		})
@@ -150,41 +147,38 @@ func TestEnsureBranchCheckedOut(t *testing.T) {
 				return json.RawMessage(b)
 			}
 
-			replay := step.RecordV1{
-				Name: t.Name(),
-				Steps: []*step.Step{
-					{
-						Name:    "Ensure Branch",
-						Inputs:  encode([]string{tt.branchName}),
-						Outputs: encode([]any{nil}),
-					},
-					{
-						Name: "git",
-						Inputs: encode([]any{
-							"git", []string{"branch"},
-						}),
-						Outputs: encode([]any{tt.response, nil}),
-						Impure:  true,
-					},
-					{
-						Name:    tt.namedValue,
-						Inputs:  encode([]any{}),
-						Outputs: encode([]any{true, nil}),
-					},
-					{
-						Name:    "git",
-						Inputs:  encode([]any{"git", tt.call}),
-						Outputs: encode([]any{"", nil}),
-						Impure:  true,
-					},
+			replay := []*step.Step{
+				{
+					Name:    "Ensure Branch",
+					Inputs:  encode([]string{tt.branchName}),
+					Outputs: encode([]any{nil}),
+				},
+				{
+					Name: "git",
+					Inputs: encode([]any{
+						"git", []string{"branch"},
+					}),
+					Outputs: encode([]any{tt.response, nil}),
+					Impure:  true,
+				},
+				{
+					Name:    tt.namedValue,
+					Inputs:  encode([]any{}),
+					Outputs: encode([]any{true, nil}),
+				},
+				{
+					Name:    "git",
+					Inputs:  encode([]any{"git", tt.call}),
+					Outputs: encode([]any{"", nil}),
+					Impure:  true,
 				},
 			}
 
 			if tt.namedValue == "" {
-				replay.Steps = append(replay.Steps[:2], replay.Steps[3:]...)
+				replay = append(replay[:2], replay[3:]...)
 			}
 			if len(tt.call) == 0 {
-				replay.Steps = replay.Steps[:len(replay.Steps)-1]
+				replay = replay[:len(replay)-1]
 			}
 
 			simpleReplay(t, replay, func(ctx context.Context) {

--- a/upgrade/upgrade_provider.go
+++ b/upgrade/upgrade_provider.go
@@ -61,20 +61,14 @@ func UpgradeProvider(ctx context.Context, repoOrg, repoName string) (err error) 
 
 	err = stepv2.PipelineCtx(ctx, "Discover Provider", func(ctx context.Context) {
 		repo.root = OrgProviderRepos(ctx, repoOrg, repoName)
+		repo.defaultBranch = pullDefaultBranch(ctx, "origin")
+		goMod = getRepoKind(ctx, repo)
 	})
-
-	discoverSteps := []step.Step{
-		PullDefaultBranch(ctx, "origin").In(&repo.root).
-			AssignTo(&repo.defaultBranch),
+	if err != nil {
+		return err
 	}
 
-	discoverSteps = append(discoverSteps, step.F("Repo kind", func(context.Context) (string, error) {
-		goMod, err = GetRepoKind(ctx, repo)
-		if err != nil {
-			return "", err
-		}
-		return string(goMod.Kind), nil
-	}))
+	discoverSteps := []step.Step{}
 
 	if GetContext(ctx).UpgradeProviderVersion {
 		discoverSteps = append(discoverSteps,

--- a/upgrade/upgrade_test.go
+++ b/upgrade/upgrade_test.go
@@ -103,9 +103,12 @@ func readFile(t *testing.T, path string) []byte {
 	return bytes
 }
 
-func simpleReplay(t *testing.T, stepReplay step.RecordV1, f func(context.Context)) {
+func simpleReplay(t *testing.T, stepReplay []*step.Step, f func(context.Context)) {
 	bytes, err := json.Marshal(step.ReplayV1{
-		Pipelines: []step.RecordV1{stepReplay},
+		Pipelines: []step.RecordV1{{
+			Name:  t.Name(),
+			Steps: stepReplay,
+		}},
 	})
 	require.NoError(t, err)
 
@@ -114,4 +117,11 @@ func simpleReplay(t *testing.T, stepReplay step.RecordV1, f func(context.Context
 
 	err = step.PipelineCtx(ctx, t.Name(), f)
 	assert.NoError(t, err)
+}
+
+func jsonMarshal[T any](t *testing.T, content string) T {
+	var dst T
+	err := json.Unmarshal([]byte(content), &dst)
+	require.NoError(t, err)
+	return dst
 }


### PR DESCRIPTION
In preparation for resolving https://github.com/pulumi/upgrade-provider/issues/198, this PR converts code up to and including target version to `stepv2` from `step (v1)`. This will allow us to add a test for `getExpectedTarget`.