### PR TITLE
Prioritize a manually specified version

### DIFF
--- a/upgrade/steps_helpers.go
+++ b/upgrade/steps_helpers.go
@@ -475,9 +475,24 @@ func getRepoExpectedLocation(ctx context.Context, cwd, repoPath string) (string,
 // sorted by semantic version. The list may be empty.
 //
 // The second argument represents a message to describe the result. It may be empty.
-var getExpectedTarget = stepv2.Func21("Get Expected Target", func(ctx context.Context, name, upstreamOrg string) *UpstreamUpgradeTarget {
+var getExpectedTarget = stepv2.Func21("Get Expected Target", func(ctx context.Context,
+	name, upstreamOrg string) *UpstreamUpgradeTarget {
 	if GetContext(ctx).TargetVersion != nil {
-		return &UpstreamUpgradeTarget{Version: GetContext(ctx).TargetVersion}
+		target := &UpstreamUpgradeTarget{Version: GetContext(ctx).TargetVersion}
+
+		// If we are also inferring versions, check if this PR will close any
+		// issues.
+		if GetContext(ctx).InferVersion {
+			for _, issue := range getExpectedTargetFromIssues(ctx, name).GHIssues {
+				if issue.Version != nil &&
+					(issue.Version.LessThan(target.Version) ||
+						issue.Version.Equal(target.Version)) {
+					target.GHIssues = append(target.GHIssues, issue)
+				}
+			}
+		}
+
+		return target
 	}
 	// InferVersion == true: use issue system, with ctx.TargetVersion limiting the version if set
 	if GetContext(ctx).InferVersion {
@@ -512,7 +527,6 @@ var getExpectedTargetLatest = stepv2.Func21E("From Upstream Releases", func(ctx 
 // This method of discovery is assumed to be specific to providers maintained by Pulumi.
 var getExpectedTargetFromIssues = stepv2.Func11E("From Issues", func(ctx context.Context,
 	name string) (*UpstreamUpgradeTarget, error) {
-	target := &UpstreamUpgradeTarget{}
 	issueList := stepv2.Cmd(ctx, "gh", "issue", "list",
 		"--state=open",
 		"--author=pulumi-bot",
@@ -554,23 +568,8 @@ var getExpectedTargetFromIssues = stepv2.Func11E("From Issues", func(ctx context
 		return versions[j].Version.LessThan(versions[i].Version)
 	})
 
-	if ctx := GetContext(ctx); ctx.TargetVersion != nil {
-		var foundTarget bool
-		for i, v := range versions {
-			if v.Version.Equal(ctx.TargetVersion) {
-				// Change the target version to be the latest that we
-				// found.
-				versions = versions[i:]
-				foundTarget = true
-				break
-			}
-		}
-		if !foundTarget {
-			return nil, fmt.Errorf("possible upgrades exist, but none match %s", ctx.TargetVersion)
-		}
-	}
-
-	target.GHIssues = versions
-	target.Version = versions[0].Version
-	return target, nil
+	return &UpstreamUpgradeTarget{
+		Version:  versions[0].Version,
+		GHIssues: versions,
+	}, nil
 })

--- a/upgrade/steps_helpers.go
+++ b/upgrade/steps_helpers.go
@@ -476,13 +476,12 @@ func getRepoExpectedLocation(ctx context.Context, cwd, repoPath string) (string,
 //
 // The second argument represents a message to describe the result. It may be empty.
 var getExpectedTarget = stepv2.Func21("Get Expected Target", func(ctx context.Context, name, upstreamOrg string) *UpstreamUpgradeTarget {
+	if GetContext(ctx).TargetVersion != nil {
+		return &UpstreamUpgradeTarget{Version: GetContext(ctx).TargetVersion}
+	}
 	// InferVersion == true: use issue system, with ctx.TargetVersion limiting the version if set
 	if GetContext(ctx).InferVersion {
 		return getExpectedTargetFromIssues(ctx, name)
-	}
-	if GetContext(ctx).TargetVersion != nil {
-		return &UpstreamUpgradeTarget{Version: GetContext(ctx).TargetVersion}
-
 	}
 	return getExpectedTargetLatest(ctx, name, upstreamOrg)
 })

--- a/upgrade/steps_helpers_test.go
+++ b/upgrade/steps_helpers_test.go
@@ -145,3 +145,43 @@ func TestGetExpectedTargetFromUpstream(t *testing.T) {
 		assert.NotNil(t, result)
 	})
 }
+
+func TestGetExpectedTargetFromTarget(t *testing.T) {
+	repo, name := "pulumi/pulumi-cloudflare", "cloudflare"
+
+	steps := jsonMarshal[[]*step.Step](t, `[
+  {
+    "name": "Get Expected Target",
+    "inputs": [
+      "`+repo+`",
+      "`+name+`"
+    ],
+    "outputs": [
+      {
+        "Version": "4.19.0",
+        "GHIssues": null
+      },
+      null
+    ]
+  }
+]`)
+
+	test := func(inferVersion bool) {
+		t.Run(fmt.Sprintf("infer-version=%t", inferVersion), func(t *testing.T) {
+			simpleReplay(t, steps, func(ctx context.Context) {
+				context := &Context{
+					GoPath:               "/Users/myuser/go",
+					UpstreamProviderName: "terraform-provider-cloudflare",
+					InferVersion:         inferVersion,
+					TargetVersion:        semver.MustParse("4.19.0"),
+				}
+				result := getExpectedTarget(context.Wrap(ctx),
+					repo, name)
+				assert.NotNil(t, result)
+			})
+		})
+	}
+
+	test(true)
+	test(false)
+}


### PR DESCRIPTION
Fixes #198 

Before this PR, there was a strict ordering for version sources:

1. From issues
1. From --target-version
1. From upstream releases.

This PR changes the ordering:

1. From `--target-version`
1. From issues
1. From upstream releases.

It also adds a little more nuance on the version sources:

If `--target-version` is passed and `--pulumi-infer-version` is set, `upgrade-provider` will respect `--target-version` but will still annotate the created PR with issues to close as appropriate.

As enabled by https://github.com/pulumi/upgrade-provider/pull/201, there are tests for these changes.