### PR TITLE
Make CI branches unique

### DIFF
--- a/step/v2/util.go
+++ b/step/v2/util.go
@@ -127,3 +127,16 @@ type FileInfo struct {
 	Mode  fs.FileMode `json:"mode"`  // file mode bits
 	IsDir bool        `json:"isDir"` // abbreviation for Mode().IsDir()
 }
+
+// GetEnv wraps os.Getenv.
+//
+// It correctly declares itself as an impure function, making it safe to use in replay
+// pipelines.
+func GetEnv(ctx context.Context, key string) string {
+	return Func11("GetEnv", func(ctx context.Context, key string) string {
+		MarkImpure(ctx)
+		result := os.Getenv(key)
+		SetLabel(ctx, key+"="+result)
+		return result
+	})(ctx, key)
+}

--- a/upgrade/steps.go
+++ b/upgrade/steps.go
@@ -7,6 +7,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/fs"
+	"math"
+	"math/rand"
 	"os"
 	"path"
 	"path/filepath"
@@ -493,11 +495,23 @@ var hasRemoteBranch = stepv2.Func11("Has Remote Branch", func(ctx context.Contex
 
 var getWorkingBranch = stepv2.Func41E("Working Branch Name", func(ctx context.Context, c Context,
 	targetBridgeVersion, targetPfVersion Ref, upgradeTarget *UpstreamUpgradeTarget) (string, error) {
+
+	ciSuffix := stepv2.Func01("Random Suffix", func(ctx context.Context) string {
+		stepv2.MarkImpure(ctx) // This needs to be impure since it is random
+		return fmt.Sprintf("-%08d", rand.Intn(int(math.Pow10(8))))
+	})
+
 	ret := func(format string, a ...any) (string, error) {
 		s := fmt.Sprintf(format, a...)
+
+		if stepv2.GetEnv(ctx, "CI") == "true" {
+			s += ciSuffix(ctx)
+		}
+
 		stepv2.SetLabel(ctx, s)
 		return s, nil
 	}
+
 	switch {
 	case c.UpgradeProviderVersion:
 		return ret("upgrade-%s-to-v%s", c.UpstreamProviderName, upgradeTarget.Version)


### PR DESCRIPTION
Fixes #200 

This changes branch naming behavior when `CI=true` (as in GH Actions) to add a random suffix to all branch names. This will prevent conflicting CI jobs from disrupting each other.