### PR TITLE
Add an extra flag to only check for an upstream version

### DIFF
--- a/main.go
+++ b/main.go
@@ -200,10 +200,7 @@ If no version is passed, the pulumi/{pkg,sdk} version will track the bridge`)
 - "sdk": Upgrade the Pulumi sdk only.
 - "pf": Upgrade the Plugin Framework only.
 - "code":     Perform some number of code migrations.
-- "check-upstream-version: Determine if we need to upgrade the upstream provider."`)
-	// TODO: hide this
-	//err := cmd.PersistentFlags().MarkHidden("pulumi-infer-version")
-	//contract.AssertNoErrorf(err, "could not mark `pulumi-infer-version` flag as hidden")
+- "check-upstream-version": Determine if we need to upgrade the upstream provider. For use in CI only."`)
 
 	cmd.PersistentFlags().BoolVar(&experimental, "experimental", false,
 		`Enable experimental features, such as auto token mapping and auto aliasing`)

--- a/main.go
+++ b/main.go
@@ -132,8 +132,14 @@ func cmd() *cobra.Command {
 				case "pf":
 					set(&context.UpgradePfVersion)
 				case "check-upstream-version":
+					if targetVersion != "" {
+						return fmt.Errorf(
+							"--kind check-upstream-version is incompatible with --target-version, cannot set both",
+						)
+					}
 					set(&context.UpgradeProviderVersion)
-					set(&context.CheckUpstreamLatest)
+					set(&context.OnlyCheckUpstream)
+
 				default:
 					return fmt.Errorf(
 						"--kind=%s invalid. Must be one of `all`, `bridge`, `provider`, `code`, or `sdk`.",

--- a/main.go
+++ b/main.go
@@ -131,6 +131,9 @@ func cmd() *cobra.Command {
 					set(&context.UpgradeCodeMigration)
 				case "pf":
 					set(&context.UpgradePfVersion)
+				case "check-upstream-version":
+					set(&context.UpgradeProviderVersion)
+					set(&context.CheckUpstreamLatest)
 				default:
 					return fmt.Errorf(
 						"--kind=%s invalid. Must be one of `all`, `bridge`, `provider`, `code`, or `sdk`.",
@@ -196,7 +199,11 @@ If no version is passed, the pulumi/{pkg,sdk} version will track the bridge`)
 - "provider": Upgrade the upstream provider only.
 - "sdk": Upgrade the Pulumi sdk only.
 - "pf": Upgrade the Plugin Framework only.
-- "code":     Perform some number of code migrations.`)
+- "code":     Perform some number of code migrations.
+- "check-upstream-version: Determine if we need to upgrade the upstream provider."`)
+	// TODO: hide this
+	//err := cmd.PersistentFlags().MarkHidden("pulumi-infer-version")
+	//contract.AssertNoErrorf(err, "could not mark `pulumi-infer-version` flag as hidden")
 
 	cmd.PersistentFlags().BoolVar(&experimental, "experimental", false,
 		`Enable experimental features, such as auto token mapping and auto aliasing`)

--- a/upgrade/steps.go
+++ b/upgrade/steps.go
@@ -915,7 +915,6 @@ var planProviderUpgrade = stepv2.Func41E("Plan Provider Upgrade", func(ctx conte
 	repoOrg, repoName string, goMod *GoMod, repo *ProviderRepo) (*UpstreamUpgradeTarget, error) {
 	upgradeTarget := getExpectedTarget(ctx, repoOrg+"/"+repoName,
 		goMod.UpstreamProviderOrg)
-
 	if upgradeTarget == nil {
 		return nil, fmt.Errorf("could not determine an upstream version")
 	}
@@ -924,7 +923,6 @@ var planProviderUpgrade = stepv2.Func41E("Plan Provider Upgrade", func(ctx conte
 		GetContext(ctx).UpgradeProviderVersion = false
 		GetContext(ctx).MajorVersionBump = false
 		stepv2.SetLabel(ctx, "Up to date")
-
 		return nil, nil
 	}
 

--- a/upgrade/steps.go
+++ b/upgrade/steps.go
@@ -915,15 +915,16 @@ var planProviderUpgrade = stepv2.Func41E("Plan Provider Upgrade", func(ctx conte
 	repoOrg, repoName string, goMod *GoMod, repo *ProviderRepo) (*UpstreamUpgradeTarget, error) {
 	upgradeTarget := getExpectedTarget(ctx, repoOrg+"/"+repoName,
 		goMod.UpstreamProviderOrg)
+
 	if upgradeTarget == nil {
 		return nil, fmt.Errorf("could not determine an upstream version")
 	}
-
 	// If we don't have any upgrades to target, assume that we don't need to upgrade.
 	if upgradeTarget.Version == nil {
 		GetContext(ctx).UpgradeProviderVersion = false
 		GetContext(ctx).MajorVersionBump = false
 		stepv2.SetLabel(ctx, "Up to date")
+
 		return nil, nil
 	}
 
@@ -963,7 +964,7 @@ var planProviderUpgrade = stepv2.Func41E("Plan Provider Upgrade", func(ctx conte
 			GetContext(ctx).MajorVersionBump = false
 			msg = "Up to date"
 
-		// Target version is greater then the current version, so upgrade
+		// Target version is greater than the current version, so upgrade
 		case -1:
 			msg = fmt.Sprintf("%s -> %s",
 				repo.currentUpstreamVersion,

--- a/upgrade/steps_helpers.go
+++ b/upgrade/steps_helpers.go
@@ -583,14 +583,14 @@ var createUpstreamUpgradeIssue = stepv2.Func40E("Ensure Upstream Issue", func(ct
 	upstreamProviderName := GetContext(ctx).UpstreamProviderName
 	upstreamOrg := goMod.UpstreamProviderOrg
 
-	title := fmt.Sprintf("THIS IS ANOTHER TEST Upgrade %s to v%s", upstreamProviderName, version)
+	title := fmt.Sprintf("Upgrade %s to v%s", upstreamProviderName, version)
 
 	getIssues := exec.CommandContext(ctx, "gh", "search", "issues",
 		title,
 		"--repo="+repoOrg+"/"+repoName,
 		"--json=title,number",
 		"--state=open",
-		//"--author=@me",
+		"--author=@me",
 	)
 	ghSearchBytes := new(bytes.Buffer)
 	getIssues.Stdout = ghSearchBytes
@@ -614,6 +614,7 @@ var createUpstreamUpgradeIssue = stepv2.Func40E("Ensure Upstream Issue", func(ct
 			"--repo="+repoOrg+"/"+repoName,
 			"--body=Release details: https://github.com/"+upstreamOrg+"/"+upstreamProviderName+"/releases/tag/v"+version,
 			"--title="+title,
+			"--label="+"kind/enhancement",
 		)
 		if err = cmd.Run(); err != nil {
 			return fmt.Errorf("failed to create new issue: %w", err)

--- a/upgrade/upgrade_provider.go
+++ b/upgrade/upgrade_provider.go
@@ -70,6 +70,18 @@ func UpgradeProvider(ctx context.Context, repoOrg, repoName string) (err error) 
 		return err
 	}
 
+	// When we're only running a version check, we exit early.
+	if GetContext(ctx).CheckUpstreamLatest {
+		// UpgradeProviderVersion may be set to False at this point. We check again.
+		if GetContext(ctx).UpgradeProviderVersion {
+			fmt.Printf("New upstream version detected: %s\n", upgradeTarget.Version.String())
+		} else {
+			fmt.Println(colorize.Bold("No new upstream version detected. Everything up to date."))
+		}
+		//return early, as this is only a check.
+		return nil
+	}
+
 	discoverSteps := []step.Step{}
 
 	if GetContext(ctx).UpgradeBridgeVersion {

--- a/upgrade/upgrade_provider.go
+++ b/upgrade/upgrade_provider.go
@@ -71,19 +71,22 @@ func UpgradeProvider(ctx context.Context, repoOrg, repoName string) (err error) 
 	}
 
 	// When we're running a version check, we create the upgrade issue, and then exit.
-	if GetContext(ctx).CheckUpstreamLatest {
+	if GetContext(ctx).OnlyCheckUpstream {
 		// UpgradeProviderVersion may be set to False at this point. We check again.
 		if GetContext(ctx).UpgradeProviderVersion {
-			pipelineName := fmt.Sprintf("New upstream version detected: v%s\n", upgradeTarget.Version.String())
-			err = stepv2.PipelineCtx(ctx, pipelineName, func(ctx context.Context) {
-				createUpstreamUpgradeIssue(ctx, repoOrg, repoName, upgradeTarget.Version.String(), goMod)
+			pipelineName := fmt.Sprintf("New upstream version detected: v%s", upgradeTarget.Version)
+			return stepv2.PipelineCtx(ctx, pipelineName, func(ctx context.Context) {
+				createUpstreamUpgradeIssue(ctx,
+					repoOrg,
+					repoName,
+					upgradeTarget.Version.String(),
+					goMod.UpstreamProviderOrg,
+				)
 			})
-			if err != nil {
-				return err
-			}
-		} else {
-			fmt.Println(colorize.Bold("No new upstream version detected. Everything up to date."))
+
 		}
+		fmt.Println(colorize.Bold("No new upstream version detected. Everything up to date."))
+
 		return nil
 	}
 

--- a/upgrade/util.go
+++ b/upgrade/util.go
@@ -24,9 +24,11 @@ type Context struct {
 	// An optional path to clone the provider repo to
 	repoPath string
 
-	TargetVersion       *semver.Version
-	InferVersion        bool
-	CheckUpstreamLatest bool
+	TargetVersion *semver.Version
+	InferVersion  bool
+	// For CI - check and see if upstream is ahead of this provider.
+	// If so, create a GH issue and exit. Do not attempt to upgrade the provider.
+	OnlyCheckUpstream bool
 
 	UpgradeBridgeVersion bool
 	TargetBridgeRef      Ref

--- a/upgrade/util.go
+++ b/upgrade/util.go
@@ -24,8 +24,9 @@ type Context struct {
 	// An optional path to clone the provider repo to
 	repoPath string
 
-	TargetVersion *semver.Version
-	InferVersion  bool
+	TargetVersion       *semver.Version
+	InferVersion        bool
+	CheckUpstreamLatest bool
 
 	UpgradeBridgeVersion bool
 	TargetBridgeRef      Ref


### PR DESCRIPTION
Add a flag option `check-upstream-provider` to check whether we are on the latest upstream version, and open a "Upgrade terraform-provider-foo" issue on the provider repo in question if none exists.

This functionality is meant to be used in a CI context and will check for upstream provider releases on a cron schedule. 

The created issue will then trigger our existing update workflow. A test PR is [here](https://github.com/pulumi/pulumi-akamai/issues/341) and we can see it triggered the upgrade action accordingly.

Next step will be adding this cron workflow to a few canary providers.

Part of https://github.com/pulumi/ci-mgmt/issues/724 - this step will allow us to remove dependency on https://github.com/pulumi/github-issue-automation. If this performs as expected, followup work will trigger an upgrade workflow directly once CI detects a new version.
