### PR TITLE
Remove --create-failure-issue

### DIFF
--- a/upgrade/util.go
+++ b/upgrade/util.go
@@ -58,11 +58,10 @@ type Context struct {
 	UpgradeCodeMigration bool
 	MigrationOpts        []string
 
-	AllowMissingDocs   bool
-	RemovePlugins      bool
-	PrReviewers        string
-	PrAssign           string
-	CreateFailureIssue bool
+	AllowMissingDocs bool
+	RemovePlugins    bool
+	PrReviewers      string
+	PrAssign         string
 
 	PRDescription string
 }


### PR DESCRIPTION
This flag is not reliable, since it relies on `upgrade-provider` passing the pre-check, not panicking during execution and then successfully creating a GH issue. A known failure path for GitHub Actions is OOM on the runner, which exits before this can run. Because of this common failure case, we don't use this flag in any of our providers.

Instead of a flag like this, we would recommend monitoring actions from outside the VM running the action.