### PR TITLE
Detect and upgrade Java Gen Version.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .idea/
 vendor/
 bin/
+upgrade-provider

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/briandowns/spinner v1.20.0
 	github.com/hexops/autogold/v2 v2.2.1
 	github.com/pulumi/pulumi/sdk/v3 v3.87.0
+	github.com/ryboe/q v1.0.20
 	github.com/spf13/cobra v1.7.0
 	github.com/spf13/pflag v1.0.5
 	github.com/spf13/viper v1.15.0
@@ -21,7 +22,10 @@ require (
 	github.com/hexops/autogold v1.3.1 // indirect
 	github.com/hexops/gotextdiff v1.0.3 // indirect
 	github.com/hexops/valast v1.4.4 // indirect
+	github.com/kr/pretty v0.3.1 // indirect
+	github.com/kr/text v0.2.0 // indirect
 	github.com/nightlyone/lockfile v1.0.0 // indirect
+	github.com/rogpeppe/go-internal v1.11.0 // indirect
 	gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c // indirect
 	gopkg.in/ini.v1 v1.67.0 // indirect
 	mvdan.cc/gofumpt v0.5.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,6 @@ require (
 	github.com/briandowns/spinner v1.20.0
 	github.com/hexops/autogold/v2 v2.2.1
 	github.com/pulumi/pulumi/sdk/v3 v3.87.0
-	github.com/ryboe/q v1.0.20
 	github.com/spf13/cobra v1.7.0
 	github.com/spf13/pflag v1.0.5
 	github.com/spf13/viper v1.15.0
@@ -22,8 +21,6 @@ require (
 	github.com/hexops/autogold v1.3.1 // indirect
 	github.com/hexops/gotextdiff v1.0.3 // indirect
 	github.com/hexops/valast v1.4.4 // indirect
-	github.com/kr/pretty v0.3.1 // indirect
-	github.com/kr/text v0.2.0 // indirect
 	github.com/nightlyone/lockfile v1.0.0 // indirect
 	github.com/rogpeppe/go-internal v1.11.0 // indirect
 	gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c // indirect

--- a/go.sum
+++ b/go.sum
@@ -194,9 +194,12 @@ github.com/pulumi/pulumi/sdk/v3 v3.87.0/go.mod h1:vexSGJ5L834l3T7Fo/KpdywjGAgZ2C
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
 github.com/rogpeppe/go-internal v1.6.1/go.mod h1:xXDCJY+GAPziupqXw64V24skbSoqbTEfhy4qGm1nDQc=
 github.com/rogpeppe/go-internal v1.9.0/go.mod h1:WtVeX8xhTBvf0smdhujwtBcq4Qrzq/fJaraNFVN+nFs=
-github.com/rogpeppe/go-internal v1.10.0 h1:TMyTOH3F/DB16zRVcYyreMH6GnZZrwQVAoYjRBZyWFQ=
 github.com/rogpeppe/go-internal v1.10.0/go.mod h1:UQnix2H7Ngw/k4C5ijL5+65zddjncjaFoBhdsK/akog=
+github.com/rogpeppe/go-internal v1.11.0 h1:cWPaGQEPrBb5/AsnsZesgZZ9yb1OQ+GOISoDNXVBh4M=
+github.com/rogpeppe/go-internal v1.11.0/go.mod h1:ddIwULY96R17DhadqLgMfk9H9tvdUzkipdSkR5nkCZA=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
+github.com/ryboe/q v1.0.20 h1:FDaGYR2WrXMrWFzklRXWJZvhAPQr07SMLVf3bCAGhVQ=
+github.com/ryboe/q v1.0.20/go.mod h1:IiqlbBPRrComXDcFXCKyIGle2yPqmgPKLJAMJQZjcgA=
 github.com/spf13/afero v1.9.5 h1:stMpOSZFs//0Lv29HduCmli3GUfpFoF3Y1Q/aXj/wVM=
 github.com/spf13/afero v1.9.5/go.mod h1:UBogFpq8E9Hx+xc5CNTTEpTnuHVmXDwZcZcE1eb/UhQ=
 github.com/spf13/cast v1.5.0 h1:rj3WzYc11XZaIZMPKmwP96zkFEnnAmV8s6XbB2aY32w=

--- a/go.sum
+++ b/go.sum
@@ -198,8 +198,6 @@ github.com/rogpeppe/go-internal v1.10.0/go.mod h1:UQnix2H7Ngw/k4C5ijL5+65zddjncj
 github.com/rogpeppe/go-internal v1.11.0 h1:cWPaGQEPrBb5/AsnsZesgZZ9yb1OQ+GOISoDNXVBh4M=
 github.com/rogpeppe/go-internal v1.11.0/go.mod h1:ddIwULY96R17DhadqLgMfk9H9tvdUzkipdSkR5nkCZA=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
-github.com/ryboe/q v1.0.20 h1:FDaGYR2WrXMrWFzklRXWJZvhAPQr07SMLVf3bCAGhVQ=
-github.com/ryboe/q v1.0.20/go.mod h1:IiqlbBPRrComXDcFXCKyIGle2yPqmgPKLJAMJQZjcgA=
 github.com/spf13/afero v1.9.5 h1:stMpOSZFs//0Lv29HduCmli3GUfpFoF3Y1Q/aXj/wVM=
 github.com/spf13/afero v1.9.5/go.mod h1:UBogFpq8E9Hx+xc5CNTTEpTnuHVmXDwZcZcE1eb/UhQ=
 github.com/spf13/cast v1.5.0 h1:rj3WzYc11XZaIZMPKmwP96zkFEnnAmV8s6XbB2aY32w=

--- a/main.go
+++ b/main.go
@@ -158,6 +158,9 @@ func cmd() *cobra.Command {
 		},
 	}
 
+	cmd.PersistentFlags().BoolVar(&context.UpgradeJavaVersion, "upgrade-java", true,
+		`Upgrade to the latest Java version`)
+
 	cmd.PersistentFlags().StringVar(&repoPath, "repo-path", "",
 		`Clone the provider repo to the specified path.`)
 

--- a/main.go
+++ b/main.go
@@ -160,6 +160,8 @@ func cmd() *cobra.Command {
 
 	cmd.PersistentFlags().BoolVar(&context.UpgradeJavaVersion, "upgrade-java", true,
 		`Upgrade to the latest Java version`)
+	err := cmd.PersistentFlags().MarkHidden("upgrade-java")
+	contract.AssertNoErrorf(err, "could not mark `upgrade-java` flag as hidden")
 
 	cmd.PersistentFlags().StringVar(&repoPath, "repo-path", "",
 		`Clone the provider repo to the specified path.`)
@@ -178,7 +180,7 @@ If no version is passed, the pulumi/{pkg,sdk} version will track the bridge`)
 		`Use our GH issues to infer the target upgrade version.
 		If both '--target-version' and '--pulumi-infer-version' are passed,
 		we take '--target-version' to cap the inferred version. [Hidden behind PULUMI_DEV]`)
-	err := cmd.PersistentFlags().MarkHidden("pulumi-infer-version")
+	err = cmd.PersistentFlags().MarkHidden("pulumi-infer-version")
 	contract.AssertNoErrorf(err, "could not mark `pulumi-infer-version` flag as hidden")
 
 	cmd.PersistentFlags().BoolVar(&context.MajorVersionBump, "major", false,

--- a/upgrade/steps.go
+++ b/upgrade/steps.go
@@ -25,6 +25,7 @@ import (
 	"github.com/pulumi/upgrade-provider/colorize"
 	"github.com/pulumi/upgrade-provider/step"
 	stepv2 "github.com/pulumi/upgrade-provider/step/v2"
+	"github.com/ryboe/q"
 )
 
 // A "git commit" step that is resilient to no changes in the directory.
@@ -157,6 +158,9 @@ func UpgradeProviderVersion(
 	repo ProviderRepo, targetSHA, forkedProviderUpstreamCommit string,
 ) step.Step {
 	steps := []step.Step{}
+	q.Q(GetContext(ctx))
+	q.Q(GetContext(ctx).JavaVersion)
+
 	if javaVersion := GetContext(ctx).JavaVersion; javaVersion != "" {
 		var didChange bool
 		steps = append(steps, step.Combined("Update Java Version",

--- a/upgrade/steps.go
+++ b/upgrade/steps.go
@@ -328,6 +328,8 @@ var InformGitHub = stepv2.Func70E("Inform Github", func(
 		prTitle = "Upgrade pulumi-terraform-bridge/pf to " + targetPfVersion.String()
 	case c.TargetPulumiVersion != nil:
 		prTitle = "Test: Upgrade pulumi/{pkg,sdk} to " + c.TargetPulumiVersion.String()
+	case c.UpgradeJavaVersion:
+		prTitle = "Upgrade pulumi-java to" + c.JavaVersion
 	default:
 		return fmt.Errorf("Unknown action")
 	}
@@ -529,6 +531,8 @@ var getWorkingBranch = stepv2.Func41E("Working Branch Name", func(ctx context.Co
 		return ret("upgrade-pf-version-to-%s", targetPfVersion)
 	case c.TargetPulumiVersion != nil:
 		return ret("upgrade-pulumi-version-to-%s", c.TargetPulumiVersion)
+	case c.UpgradeJavaVersion:
+		return ret("upgrade-java-version-to-%s", c.JavaVersion)
 	default:
 		return "", fmt.Errorf("calculating branch name: unknown action")
 	}

--- a/upgrade/steps.go
+++ b/upgrade/steps.go
@@ -161,40 +161,40 @@ func UpgradeProviderVersion(
 	q.Q(GetContext(ctx))
 	q.Q(GetContext(ctx).JavaVersion)
 
-	if javaVersion := GetContext(ctx).JavaVersion; javaVersion != "" {
-		var didChange bool
-		steps = append(steps, step.Combined("Update Java Version",
-			step.F("Current Java Version", func(cx context.Context) (string, error) {
-				b, err := baseFileAt(cx, repo, "Makefile")
-				if err != nil {
-					return "", err
-				}
-				found := javaVersionRegexp.FindSubmatch(b)
-				if found == nil {
-					return "not found", nil
-				}
-				oldJavaVersion := string(found[1])
-				GetContext(ctx).oldJavaVersion = oldJavaVersion
-				return oldJavaVersion, nil
-			}),
-			UpdateFileWithSignal("Update Makefile", "Makefile", &didChange,
-				func(b []byte) ([]byte, error) {
-					version := javaVersionRegexp.FindSubmatchIndex(b)
-					if version == nil {
-						return nil, fmt.Errorf("Java version set: could not find JAVA_GEN_VERSION")
-					}
-					var out bytes.Buffer
-					out.Write(b[:version[2]])
-					out.WriteString(javaVersion)
-					out.Write(b[version[3]:])
-					return out.Bytes(), nil
-				}),
-			step.When(&didChange,
-				step.Cmd("rm", "-f", filepath.Join("bin", "pulumi-java-gen"))),
-			step.When(&didChange,
-				step.Cmd("rm", "-f", filepath.Join("bin", "pulumi-language-java"))),
-		))
-	}
+	//if javaVersion := GetContext(ctx).JavaVersion; javaVersion != "" {
+	//	var didChange bool
+	//	steps = append(steps, step.Combined("Update Java Version",
+	//		step.F("Current Java Version", func(cx context.Context) (string, error) {
+	//			b, err := baseFileAt(cx, repo, "Makefile")
+	//			if err != nil {
+	//				return "", err
+	//			}
+	//			found := javaVersionRegexp.FindSubmatch(b)
+	//			if found == nil {
+	//				return "not found", nil
+	//			}
+	//			oldJavaVersion := string(found[1])
+	//			GetContext(ctx).oldJavaVersion = oldJavaVersion
+	//			return oldJavaVersion, nil
+	//		}),
+	//		UpdateFileWithSignal("Update Makefile", "Makefile", &didChange,
+	//			func(b []byte) ([]byte, error) {
+	//				version := javaVersionRegexp.FindSubmatchIndex(b)
+	//				if version == nil {
+	//					return nil, fmt.Errorf("Java version set: could not find JAVA_GEN_VERSION")
+	//				}
+	//				var out bytes.Buffer
+	//				out.Write(b[:version[2]])
+	//				out.WriteString(javaVersion)
+	//				out.Write(b[version[3]:])
+	//				return out.Bytes(), nil
+	//			}),
+	//		step.When(&didChange,
+	//			step.Cmd("rm", "-f", filepath.Join("bin", "pulumi-java-gen"))),
+	//		step.When(&didChange,
+	//			step.Cmd("rm", "-f", filepath.Join("bin", "pulumi-language-java"))),
+	//	))
+	//}
 	if goMod.Kind.IsPatched() {
 		// If the provider is patched, we don't use the go module system at all. Instead
 		// we update the module referenced to the new tag.
@@ -922,6 +922,8 @@ var planProviderUpgrade = stepv2.Func41E("Plan Provider Upgrade", func(ctx conte
 	if upgradeTarget == nil {
 		return nil, fmt.Errorf("could not determine an upstream version")
 	}
+
+	q.Q(GetContext(ctx))
 	// If we don't have any upgrades to target, assume that we don't need to upgrade.
 	if upgradeTarget.Version == nil {
 		GetContext(ctx).UpgradeProviderVersion = false

--- a/upgrade/steps.go
+++ b/upgrade/steps.go
@@ -289,7 +289,7 @@ var InformGitHub = stepv2.Func70E("Inform Github", func(
 	case c.TargetPulumiVersion != nil:
 		prTitle = "Test: Upgrade pulumi/{pkg,sdk} to " + c.TargetPulumiVersion.String()
 	case c.UpgradeJavaVersion:
-		prTitle = "Upgrade pulumi-java to" + c.JavaVersion
+		prTitle = "Upgrade pulumi-java to " + c.JavaVersion
 	default:
 		return fmt.Errorf("Unknown action")
 	}

--- a/upgrade/steps.go
+++ b/upgrade/steps.go
@@ -25,7 +25,6 @@ import (
 	"github.com/pulumi/upgrade-provider/colorize"
 	"github.com/pulumi/upgrade-provider/step"
 	stepv2 "github.com/pulumi/upgrade-provider/step/v2"
-	"github.com/ryboe/q"
 )
 
 // A "git commit" step that is resilient to no changes in the directory.
@@ -151,50 +150,11 @@ var ensureUpstreamRepo = stepv2.Func11("Ensure Upstream Repo", func(ctx context.
 	return expectedLocation
 })
 
-var javaVersionRegexp *regexp.Regexp = regexp.MustCompile(`JAVA_GEN_VERSION := (v[0-9]+\.[0-9]+\.[0-9]+)`)
-
 func UpgradeProviderVersion(
 	ctx context.Context, goMod *GoMod, target *semver.Version,
 	repo ProviderRepo, targetSHA, forkedProviderUpstreamCommit string,
 ) step.Step {
 	steps := []step.Step{}
-	q.Q(GetContext(ctx))
-	q.Q(GetContext(ctx).JavaVersion)
-
-	//if javaVersion := GetContext(ctx).JavaVersion; javaVersion != "" {
-	//	var didChange bool
-	//	steps = append(steps, step.Combined("Update Java Version",
-	//		step.F("Current Java Version", func(cx context.Context) (string, error) {
-	//			b, err := baseFileAt(cx, repo, "Makefile")
-	//			if err != nil {
-	//				return "", err
-	//			}
-	//			found := javaVersionRegexp.FindSubmatch(b)
-	//			if found == nil {
-	//				return "not found", nil
-	//			}
-	//			oldJavaVersion := string(found[1])
-	//			GetContext(ctx).oldJavaVersion = oldJavaVersion
-	//			return oldJavaVersion, nil
-	//		}),
-	//		UpdateFileWithSignal("Update Makefile", "Makefile", &didChange,
-	//			func(b []byte) ([]byte, error) {
-	//				version := javaVersionRegexp.FindSubmatchIndex(b)
-	//				if version == nil {
-	//					return nil, fmt.Errorf("Java version set: could not find JAVA_GEN_VERSION")
-	//				}
-	//				var out bytes.Buffer
-	//				out.Write(b[:version[2]])
-	//				out.WriteString(javaVersion)
-	//				out.Write(b[version[3]:])
-	//				return out.Bytes(), nil
-	//			}),
-	//		step.When(&didChange,
-	//			step.Cmd("rm", "-f", filepath.Join("bin", "pulumi-java-gen"))),
-	//		step.When(&didChange,
-	//			step.Cmd("rm", "-f", filepath.Join("bin", "pulumi-language-java"))),
-	//	))
-	//}
 	if goMod.Kind.IsPatched() {
 		// If the provider is patched, we don't use the go module system at all. Instead
 		// we update the module referenced to the new tag.
@@ -926,8 +886,6 @@ var planProviderUpgrade = stepv2.Func41E("Plan Provider Upgrade", func(ctx conte
 	if upgradeTarget == nil {
 		return nil, fmt.Errorf("could not determine an upstream version")
 	}
-
-	q.Q(GetContext(ctx))
 	// If we don't have any upgrades to target, assume that we don't need to upgrade.
 	if upgradeTarget.Version == nil {
 		GetContext(ctx).UpgradeProviderVersion = false

--- a/upgrade/steps_helpers.go
+++ b/upgrade/steps_helpers.go
@@ -159,7 +159,7 @@ func prBody(ctx context.Context, repo ProviderRepo,
 	if GetContext(ctx).MajorVersionBump {
 		fmt.Fprintf(b, "- Updating major version from %s to %s.\n", repo.currentVersion, repo.currentVersion.IncMajor())
 	}
-	if ctx := GetContext(ctx); ctx.oldJavaVersion != ctx.JavaVersion && ctx.JavaVersion != "" {
+	if ctx := GetContext(ctx); ctx.UpgradeJavaVersion && ctx.JavaVersion != "" {
 		var from string
 		if prev := ctx.oldJavaVersion; prev != "" {
 			from = fmt.Sprintf("from %s ", prev)

--- a/upgrade/steps_helpers.go
+++ b/upgrade/steps_helpers.go
@@ -164,7 +164,7 @@ func prBody(ctx context.Context, repo ProviderRepo,
 		if prev := ctx.oldJavaVersion; prev != "" {
 			from = fmt.Sprintf("from %s ", prev)
 		}
-		fmt.Fprintf(b, "- Updating java version %sto %s.\n", from, ctx.JavaVersion)
+		fmt.Fprintf(b, "- Updating Java Gen version %sto %s.\n", from, ctx.JavaVersion)
 	}
 
 	if GetContext(ctx).UpgradeProviderVersion {

--- a/upgrade/upgrade_provider.go
+++ b/upgrade/upgrade_provider.go
@@ -245,10 +245,18 @@ func UpgradeProvider(ctx context.Context, repoOrg, repoName string) (err error) 
 			}
 
 			stepv2.Func00E("Fetching latest Java Gen", func(ctx context.Context) error {
-				currentJavaGen := stepv2.ReadFile(ctx, ".pulumi/java-gen-version")
+
 				latestJavaGen, err := latestRelease(ctx, "pulumi/pulumi-java")
 				if err != nil {
 					return fmt.Errorf("error fetching latest Java release %v", err)
+				}
+				var currentJavaGen string
+				_, exists := stepv2.Stat(ctx, ".pulumi/java-gen-version")
+				if !exists {
+					// use dummy placeholder in lieu of reading from file
+					currentJavaGen = "0.0.0"
+				} else {
+					currentJavaGen = stepv2.ReadFile(ctx, ".pulumi/java-gen-version")
 				}
 				// we do not upgrade Java if the two versions are the same
 				if latestJavaGen.String() == currentJavaGen {

--- a/upgrade/upgrade_provider.go
+++ b/upgrade/upgrade_provider.go
@@ -97,6 +97,10 @@ func UpgradeProvider(ctx context.Context, repoOrg, repoName string) (err error) 
 
 		return nil
 	}
+	// do not upgrade Java on bridge-only upgrades
+	if GetContext(ctx).UpgradeBridgeVersion && !GetContext(ctx).UpgradeProviderVersion {
+		GetContext(ctx).UpgradeJavaVersion = false
+	}
 
 	discoverSteps := []step.Step{}
 
@@ -234,7 +238,6 @@ func UpgradeProvider(ctx context.Context, repoOrg, repoName string) (err error) 
 	}
 
 	if GetContext(ctx).UpgradeJavaVersion {
-
 		err = stepv2.PipelineCtx(ctx, "Planning Java Gen Version Update", func(ctx context.Context) {
 			if GetContext(ctx).JavaVersion != "" {
 				// we are pinning a java gen version via `--java-version`, so we will not query for latest.

--- a/upgrade/upgrade_provider.go
+++ b/upgrade/upgrade_provider.go
@@ -97,10 +97,6 @@ func UpgradeProvider(ctx context.Context, repoOrg, repoName string) (err error) 
 
 		return nil
 	}
-	// do not upgrade Java on bridge-only upgrades
-	if GetContext(ctx).UpgradeBridgeVersion && !GetContext(ctx).UpgradeProviderVersion {
-		GetContext(ctx).UpgradeJavaVersion = false
-	}
 
 	discoverSteps := []step.Step{}
 
@@ -254,12 +250,12 @@ func UpgradeProvider(ctx context.Context, repoOrg, repoName string) (err error) 
 					return fmt.Errorf("error fetching latest Java release %v", err)
 				}
 				var currentJavaGen string
-				_, exists := stepv2.Stat(ctx, ".pulumi/java-gen-version")
+				_, exists := stepv2.Stat(ctx, ".pulumi-java-gen.version")
 				if !exists {
 					// use dummy placeholder in lieu of reading from file
 					currentJavaGen = "0.0.0"
 				} else {
-					currentJavaGen = stepv2.ReadFile(ctx, ".pulumi/java-gen-version")
+					currentJavaGen = stepv2.ReadFile(ctx, ".pulumi-java-gen.version")
 				}
 				// we do not upgrade Java if the two versions are the same
 				if latestJavaGen.String() == currentJavaGen {
@@ -491,7 +487,7 @@ func tfgenAndBuildSDKs(
 		}
 		// Write Java Gen Version file
 		if GetContext(ctx).UpgradeJavaVersion {
-			stepv2.WriteFile(ctx, ".pulumi/java-gen-version", GetContext(ctx).JavaVersion)
+			stepv2.WriteFile(ctx, ".pulumi-java-gen.version", GetContext(ctx).JavaVersion)
 		}
 
 		stepv2.Cmd(ctx, "make", "tfgen")

--- a/upgrade/util.go
+++ b/upgrade/util.go
@@ -38,6 +38,8 @@ type Context struct {
 	UpgradeProviderVersion bool
 	MajorVersionBump       bool
 
+	UpgradeJavaVersion bool
+
 	// The unqualified name of the upstream provider.
 	//
 	// As an example, Pulumi's AWS provider has:


### PR DESCRIPTION
This PR depends on a few provider repository structure tweaks as prerequisites.

1. In order to properly track and check in the current Java Gen version, we will write this version to a file `.pulumi/java-gen-version`. Native providers use this pattern as a dependencies tracker already so this is not new.
2. We will start to check in the version files in the `.pulumi` folder - both `version` (meaning pulumi itself) and `java-gen-version`. The plugins will remain gitignored.
3. In the Makefile, rather than reading in the `JAVA_GEN_VERSION` during a CI upgrade (which does not build SDKs), we will depend on `.pulumi/java-gen-version` for the `bin/pulumi-java-gen` target. [Example Makefile changes](https://github.com/pulumi/pulumi-aiven/pull/446/files#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52)(https://github.com/pulumi/pulumi-aiven/pull/446/files#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52)
4. _Only a full upgrade using upgrade-provider (or running the equivalent manual steps)_ will be updating the `.pulumi/java-gen-version` file.
5. We slightly change the meaning of `javaGenVersion` for ci and upgrade configs; we will use this option as a means to pin the Java Gen version, should we need to ever roll back in a provider.

This PR lays down the groundwork for points  1, 4, and 5.

- add new boolean flag `--upgrade-java` that defaults to true
- check the version read from `.pulumi/pulumi-java-gen`, compare to the latest version of pulumi-java, and upgrade when necessary
- we retain the ability to pin a version via `upgrade-provider provider/repo --java-version=x.y.z`. In this case, we set the `.pulumi/java-gen-version` to that version, and do not upgrade to anything newer.

Parts 2&3 will be changed via ci-mgmt.

Part of https://github.com/pulumi/ci-mgmt/issues/506.