### PR TITLE
Correctly obtain upstream org name for provider

### DIFF
--- a/upgrade/kind.go
+++ b/upgrade/kind.go
@@ -186,7 +186,7 @@ var getRepoKind = stepv2.Func11E("Get Repo Kind", func(ctx context.Context, repo
 		Pf:       pf,
 	}
 
-	upstreamOrg := stepv2.Func11("Get UpstreamOrg", func(ctx context.Context, path string) string {
+	out.UpstreamProviderOrg = stepv2.Func11("Get UpstreamOrg", func(ctx context.Context, path string) string {
 		stepv2.SetLabel(ctx, "From resources.go")
 		resourceFile := filepath.Join(path, "provider", "resources.go")
 		resourceData := stepv2.ReadFile(ctx, resourceFile)
@@ -207,10 +207,6 @@ var getRepoKind = stepv2.Func11E("Get Repo Kind", func(ctx context.Context, repo
 		}
 		return upstreamOrg
 	})(ctx, path)
-
-	out.UpstreamProviderOrg = upstreamOrg
-
-	// get the org name that hosts the upstream repo from the GitHubOrg field in provider/resources.go
 
 	if fork == nil {
 		out.Kind = Plain

--- a/upgrade/kind.go
+++ b/upgrade/kind.go
@@ -198,7 +198,9 @@ var getRepoKind = stepv2.Func11E("Get Repo Kind", func(ctx context.Context, repo
 		}
 	}
 	if upstreamOrg == "" {
-		contract.Assertf(upstreamOrg != "nil", "upstreamOrg cannot be empty; set GitHubOrg in ProviderInfo")
+		// fall back to attempting to read from go.mod
+		tok := strings.Split(modPathWithoutVersion(upstream.Mod.Path), "/")
+		out.UpstreamProviderOrg = tok[len(tok)-2]
 	}
 	out.UpstreamProviderOrg = upstreamOrg
 


### PR DESCRIPTION
Inferring the upstream provider org from the go mod requirements is not as robust as once believed.
This pull request reads from provider/resources.go instead, looking for the value of `GitHubOrg`.

This change will unblock Stateless Provider Upgrades rollout, and it will additionally ensure that the fallback behavior for the "Get Expected Target / From Upstream Releases" works correctly for all providers.

A successful run using this commit is here: https://github.com/pulumi/pulumi-gitlab/actions/runs/7201244400/job/19616931040 - it is broken using `upgrade-provider@main`.

Fixes #213
