### PR TITLE
Fix the flake

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,16 +2,16 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1699596684,
-        "narHash": "sha256-XSXP8zjBZJBVvpNb2WmY0eW8O2ce+sVyj1T0/iBRIvg=",
+        "lastModified": 1702346276,
+        "narHash": "sha256-eAQgwIWApFQ40ipeOjVSoK4TEHVd6nbSd9fApiHIw5A=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "da4024d0ead5d7820f6bd15147d3fe2a0c0cec73",
+        "rev": "cf28ee258fd5f9a52de6b9865cdb93a1f96d09b7",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixos-23.05",
+        "ref": "nixos-23.11",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -2,20 +2,19 @@
   description = "A flake defining upgrade-provider build-from-source package";
 
   inputs = {
-    nixpkgs.url = github:NixOS/nixpkgs/nixos-23.05;
+    nixpkgs.url = github:NixOS/nixpkgs/nixos-23.11;
   };
 
   outputs = { self, nixpkgs }: let
 
     package = { system }: let
       pkgs = import nixpkgs { system = system; };
-    in pkgs.buildGo120Module rec {
+    in pkgs.buildGo121Module rec {
       name = "upgrade-provider";
       version = ''${self.rev or "dirty"}'';
       src = ./.;
-      # subPackages = [ "cmd/pulumictl" ];
       doCheck = false;
-      vendorSha256 = "sha256-YBteVgcWvIE10ojd9W4grMK8kJ0zXXQiBuEHto3sABI=";
+      vendorHash = "sha256-0InHprcsXT9I1foDSFKEXzmOxl7LC0FxRe7wOsv6BTo=";
       ldflags = [];
     };
 


### PR DESCRIPTION
Due to updates in go.sum this flake does not build anymore; taking a chance to update Go toolchain as well to go21.0 for the flake build.