### PR TITLE
Use semver sort to determine latest upstream release in getExpectedTargetLatest

### DIFF
--- a/upgrade/steps_helpers.go
+++ b/upgrade/steps_helpers.go
@@ -509,28 +509,36 @@ var getExpectedTarget = stepv2.Func21("Get Expected Target", func(ctx context.Co
 // release.
 var getExpectedTargetLatest = stepv2.Func21E("From Upstream Releases", func(ctx context.Context,
 	name, upstreamOrg string) (*UpstreamUpgradeTarget, error) {
-	// TODO: use --json once https://github.com/cli/cli/issues/4572 is fixed
-	latest := stepv2.Cmd(ctx, "gh", "release", "list",
-		"--repo="+upstreamOrg+"/"+GetContext(ctx).UpstreamProviderName,
-		"--exclude-drafts",
-		"--exclude-pre-releases")
-	
-	versions := strings.Split(latest, "\n")
-	for _, ver := range versions {
-		tok := strings.Fields(ver)
-		contract.Assertf(len(tok) > 0, "no releases found in %s/%s",
-			upstreamOrg, GetContext(ctx).UpstreamProviderName)
-		v, err := semver.NewVersion(tok[0])
-		if err != nil {
-			return nil, err
-		}
-		if v.Prerelease() != "" {
-			continue
-		}
-		return &UpstreamUpgradeTarget{Version: v}, nil
+
+	//// TODO: use --json once https://github.com/cli/cli/issues/4572 is fixed
+	//latest := stepv2.Cmd(ctx, "gh", "release", "list",
+	//	"--repo="+upstreamOrg+"/"+GetContext(ctx).UpstreamProviderName,
+	//	"--exclude-drafts",
+	//	"--exclude-pre-releases")
+	//
+	//versions := strings.Split(latest, "\n")
+	//for _, ver := range versions {
+	//	tok := strings.Fields(ver)
+	//	contract.Assertf(len(tok) > 0, "no releases found in %s/%s",
+	//		upstreamOrg, GetContext(ctx).UpstreamProviderName)
+	//	v, err := semver.NewVersion(tok[0])
+	//	if err != nil {
+	//		return nil, err
+	//	}
+	//	if v.Prerelease() != "" {
+	//		continue
+	//	}
+	//	return &UpstreamUpgradeTarget{Version: v}, nil
+	//}
+	//return nil, fmt.Errorf("no non-beta releases found in %s/%s",
+	//upstreamOrg, GetContext(ctx).UpstreamProviderName)
+
+	upstreamRepo := upstreamOrg + "/" + GetContext(ctx).UpstreamProviderName
+	latest, err := latestRelease(ctx, upstreamRepo)
+	if err != nil {
+		return nil, err
 	}
-	return nil, fmt.Errorf("no non-beta releases found in %s/%s",
-	upstreamOrg, GetContext(ctx).UpstreamProviderName)
+	return &UpstreamUpgradeTarget{Version: latest}, nil
 })
 
 // Figure out what version of upstream to target by looking at specific pulumi-bot

--- a/upgrade/steps_helpers.go
+++ b/upgrade/steps_helpers.go
@@ -403,16 +403,21 @@ func (g gitRepoRefs) sortedLabels(less func(string, string) bool) []string {
 }
 
 func latestRelease(ctx context.Context, repo string) (*semver.Version, error) {
-	latestInfo := stepv2.Cmd(ctx, "gh", "repo", "view", repo, "--json=latestRelease")
+	resultBytes, err := exec.CommandContext(ctx, "gh", "repo", "view",
+		repo, "--json=latestRelease").Output()
+	if err != nil {
+		return nil, err
+	}
 	var result struct {
 		Latest struct {
 			TagName string `json:"tagName"`
 		} `json:"latestRelease"`
 	}
-	err := json.Unmarshal([]byte(latestInfo), &result)
+	err = json.Unmarshal(resultBytes, &result)
 	if err != nil {
 		return nil, err
 	}
+
 	return semver.NewVersion(result.Latest.TagName)
 }
 

--- a/upgrade/steps_helpers.go
+++ b/upgrade/steps_helpers.go
@@ -403,13 +403,13 @@ func (g gitRepoRefs) sortedLabels(less func(string, string) bool) []string {
 }
 
 func latestRelease(ctx context.Context, repo string) (*semver.Version, error) {
-	resultBytes := stepv2.CmdOutput(ctx, "gh", "repo", "view", repo, "--json=latestRelease")
+	latestInfo := stepv2.Cmd(ctx, "gh", "repo", "view", repo, "--json=latestRelease")
 	var result struct {
 		Latest struct {
 			TagName string `json:"tagName"`
 		} `json:"latestRelease"`
 	}
-	err := json.Unmarshal(resultBytes, &result)
+	err := json.Unmarshal([]byte(latestInfo), &result)
 	if err != nil {
 		return nil, err
 	}
@@ -514,7 +514,6 @@ var getExpectedTargetLatest = stepv2.Func21E("From Upstream Releases", func(ctx 
 	// In some cases, upstream marks non-stable releases as `latest`.
 	// Because we do not upgrade on those, we return an empty upstream target.
 	if version.Prerelease() != "" {
-		stepv2.SetLabel(ctx, "HITTINGG THIS ISSUE")
 		return &UpstreamUpgradeTarget{}, nil
 	}
 	return &UpstreamUpgradeTarget{Version: version}, nil

--- a/upgrade/steps_helpers.go
+++ b/upgrade/steps_helpers.go
@@ -526,18 +526,14 @@ var getExpectedTargetLatest = stepv2.Func11E("From Upstream Releases", func(ctx 
 	// Get version tags. This will become much less laborious once we can use json.
 	var tags []string
 	for _, line := range resultLines {
-		// split the result line by whitespace
-		fields := strings.Fields(line)
-		// handle empty newlines
-		if len(fields) == 0 {
+		// split the result line by tabs - there are four fields
+		fields := strings.Split(line, "\t")
+		// handle empty newlines and other nonstandard output
+		if len(fields) != 4 {
 			continue
 		}
-		// the tag name for the release is the second field of the result line.
-		tag := fields[1]
-		// except when the release is marked as Latest, then it's the third field.
-		if tag == "Latest" {
-			tag = fields[2]
-		}
+		// the tag name for the release is the third field of the result line.
+		tag := fields[2]
 		tags = append(tags, tag)
 	}
 

--- a/upgrade/steps_helpers.go
+++ b/upgrade/steps_helpers.go
@@ -477,7 +477,7 @@ var getExpectedTarget = stepv2.Func21("Get Expected Target", func(ctx context.Co
 
 	// we do not infer version from pulumi issues, or allow a target version when checking for a new upstream release
 	if GetContext(ctx).OnlyCheckUpstream {
-		return getExpectedTargetLatest(ctx, name, upstreamOrg)
+		return getExpectedTargetLatest(ctx, upstreamOrg)
 	}
 
 	if GetContext(ctx).TargetVersion != nil {
@@ -502,17 +502,18 @@ var getExpectedTarget = stepv2.Func21("Get Expected Target", func(ctx context.Co
 	if GetContext(ctx).InferVersion {
 		return getExpectedTargetFromIssues(ctx, name)
 	}
-	return getExpectedTargetLatest(ctx, name, upstreamOrg)
+	return getExpectedTargetLatest(ctx, upstreamOrg)
 })
 
 // getExpectedTargetLatest discovers the latest stable release and sets it on UpstreamUpgradeTarget.Version.
 // There is a lot of human error and differing conventions when discovering and defining the "latest" upstream version.
-// For our purposes, we always want to discover the highest, stable, valid Semver version of the upstream provider.
+// For our purposes, we always want to discover the highest, stable, valid semver, version of the upstream provider.
 // We do so by listing the last 30 GitHub releases, extracting the tags from the output result (we eagerly await being
 // able to get this result in json), parsing the tags into versions (filtering out any invalid or non-stable tags),
 // and sorting them.
-var getExpectedTargetLatest = stepv2.Func21E("From Upstream Releases", func(ctx context.Context,
-	name, upstreamOrg string) (*UpstreamUpgradeTarget, error) {
+// This is a best-effort approach. There may be edge cases in which these steps do not yield the correct latest release.
+var getExpectedTargetLatest = stepv2.Func11E("From Upstream Releases", func(ctx context.Context,
+	upstreamOrg string) (*UpstreamUpgradeTarget, error) {
 
 	upstreamRepo := upstreamOrg + "/" + GetContext(ctx).UpstreamProviderName
 	// TODO: use --json once https://github.com/cli/cli/issues/4572 is fixed

--- a/upgrade/steps_helpers_test.go
+++ b/upgrade/steps_helpers_test.go
@@ -292,40 +292,40 @@ func TestGetExpectedTargetFromTarget(t *testing.T) {
 }
 
 func TestExpectedTargetLatest(t *testing.T) {
-	repo, name := "pulumi/pulumi-akamai", "akamai"
-	expectedVersion := "5.3.0"
+	upstreamOrg := "akamai"
+	expectedVersion := "5.5.0"
 
 	simpleReplay(t, jsonMarshal[[]*step.Step](t, `[
-{
-	"name": "From Upstream Releases",
-	"inputs": [
-		"pulumi/pulumi-akamai",
+	{
+	  "name": "From Upstream Releases",
+	  "inputs": [
 		"akamai"
-	],
-	"outputs": [
+	  ],
+	  "outputs": [
 		{
-		  "Version": "5.3.0",
+		  "Version": "5.5.0",
 		  "GHIssues": null
 		},
 		null
-	]
-},
-{
-	"name": "gh",
-	"inputs": [
+	  ]
+	},
+	{
+	  "name": "gh",
+	  "inputs": [
 		"gh",
 		[
-			"repo",
-			"view",
-			"akamai/terraform-provider-akamai",
-			"--json=latestRelease"
+		  "release",
+		  "list",
+		  "--repo=akamai/terraform-provider-akamai",
+		  "--exclude-drafts",
+		  "--exclude-pre-releases"
 		]
-	],
-	"outputs": [
-		"{\"latestRelease\":{\"name\":\"v5.3.0\",\"tagName\":\"v5.3.0\",\"url\":\"https://github.com/akamai/terraform-provider-akamai/releases/tag/v5.3.0\",\"publishedAt\":\"2023-12-07T15:22:04Z\"}}\n",
+	  ],
+	  "outputs": [
+		"v5.5.0\tLatest\tv5.5.0\t2023-12-07T15:22:04Z\nv5.4.0\t\tv5.4.0\t2023-10-31T13:18:57Z\nv5.3.0\t\tv5.3.0\t2023-09-26T13:28:16Z\nv5.2.0\t\tv5.2.0\t2023-08-29T14:27:47Z\nv5.1.0\t\tv5.1.0\t2023-08-01T09:37:02Z\nv5.0.1\t\tv5.0.1\t2023-07-12T09:34:26Z\nv5.0.0\t\tv5.0.0\t2023-07-05T11:29:09Z\nv4.1.0\t\tv4.1.0\t2023-06-01T13:02:18Z\nv4.0.0\t\tv4.0.0\t2023-05-30T13:02:37Z\nv3.6.0\t\tv3.6.0\t2023-04-27T08:59:25Z\nv3.5.0\t\tv3.5.0\t2023-03-30T14:03:22Z\nv3.4.0\t\tv3.4.0\t2023-03-02T13:42:38Z\nv3.3.0\t\tv3.3.0\t2023-02-02T09:56:51Z\nv3.2.1\t\tv3.2.1\t2022-12-16T14:06:02Z\nv3.2.0\t\tv3.2.0\t2022-12-15T15:04:40Z\nv3.1.0\t\tv3.1.0\t2022-12-01T12:52:03Z\nv3.0.0\t\tv3.0.0\t2022-10-27T10:24:21Z\nv2.4.2\t\tv2.4.2\t2022-10-04T08:46:49Z\nv2.4.1\t\tv2.4.1\t2022-09-29T13:36:45Z\nv2.3.0\t\tv2.3.0\t2022-08-25T09:06:18Z\nv2.2.0\t\tv2.2.0\t2022-06-30T09:24:03Z\nv2.1.1\t\tv2.1.1\t2022-06-09T11:13:10Z\nv2.1.0\t\tv2.1.0\t2022-06-02T07:44:28Z\nv2.0.0\t\tv2.0.0\t2022-04-28T09:28:19Z\nv1.12.1\t\tv1.12.1\t2022-04-06T08:34:22Z\nv1.12.0\t\tv1.12.0\t2022-04-04T10:52:09Z\nv1.11.0\t\tv1.11.0\t2022-03-03T12:41:25Z\nv1.10.1\t\tv1.10.1\t2022-02-10T10:11:56Z\nv1.10.0\t\tv1.10.0\t2022-01-27T10:39:23Z\nv1.9.1\t\tv1.9.1\t2021-12-16T10:42:24Z\n",
 		null
-	],
-	"impure": true
+	  ],
+	  "impure": true
 	}
 ]`), func(ctx context.Context) {
 		context := &Context{
@@ -333,55 +333,55 @@ func TestExpectedTargetLatest(t *testing.T) {
 			UpstreamProviderName: "terraform-provider-akamai",
 		}
 		result := getExpectedTargetLatest(context.Wrap(ctx),
-			repo, name)
+			upstreamOrg)
 		assert.NotNil(t, result)
-		assert.Equal(t, expectedVersion, result.Version)
+		assert.Equal(t, expectedVersion, result.Version.String())
 	})
 }
 
-func TestExpectedTargetLatestBetaIgnored(t *testing.T) {
-	repo, name := "pulumi/pulumi-akamai", "akamai"
+func TestFromUpstreamReleasesBetaIgnored(t *testing.T) {
+	upstreamOrg := "cyrilgdn"
 
 	simpleReplay(t, jsonMarshal[[]*step.Step](t, `[
-{
-	"name": "From Upstream Releases",
-	"inputs": [
-		"pulumi/pulumi-akamai",
-		"akamai"
-	],
-	"outputs": [
+	{
+	  "name": "From Upstream Releases",
+	  "inputs": [
+		"cyrilgdn"
+	  ],
+	  "outputs": [
 		{
-		  "Version": null,
+		  "Version": "1.21.0",
 		  "GHIssues": null
 		},
 		null
-	]
-},
-{
-	"name": "gh",
-	"inputs": [
+	  ]
+	},
+	{
+	  "name": "gh",
+	  "inputs": [
 		"gh",
 		[
-			"repo",
-			"view",
-			"akamai/terraform-provider-akamai",
-			"--json=latestRelease"
+		  "release",
+		  "list",
+		  "--repo=cyrilgdn/terraform-provider-postgresql",
+		  "--exclude-drafts",
+		  "--exclude-pre-releases"
 		]
-	],
-	"outputs": [
-		"{\"latestRelease\":{\"name\":\"v5.5.0-beta.1\",\"tagName\":\"v5.5.0-beta.1\",\"url\":\"https://github.com/akamai/terraform-provider-akamai/releases/tag/v5.5.0-beta.1\",\"publishedAt\":\"2023-12-07T15:22:04Z\"}}\n",
+	  ],
+	  "outputs": [
+		"v1.21.1-beta.1\tLatest\tv1.21.1-beta.1\t2023-11-01T15:46:02Z\nv1.21.0\t\tv1.21.0\t2023-09-10T15:47:25Z\nv1.20.0\t\tv1.20.0\t2023-07-14T15:40:36Z\nv1.19.0\t\tv1.19.0\t2023-03-18T21:39:45Z\nv1.18.0\t\tv1.18.0\t2022-11-26T12:41:47Z\nv1.17.1\t\tv1.17.1\t2022-08-19T18:11:52Z\nv1.17.0\t\tv1.17.0\t2022-08-19T17:11:00Z\nv1.16.0\t\tv1.16.0\t2022-05-08T14:47:45Z\nv1.15.0\t\tv1.15.0\t2022-02-04T16:39:44Z\nv1.14.0\t\tv1.14.0\t2021-08-22T13:58:27Z\nv1.13.0\t\tv1.13.0\t2021-05-21T08:56:31Z\nv1.12.1\t\tv1.12.1\t2021-04-23T12:47:59Z\nv1.13.0-pre1\t\tv1.13.0-pre1\t2021-04-23T12:45:27Z\nv1.12.0\t\tv1.12.0\t2021-03-26T08:39:45Z\nv1.11.2\t\tv1.11.2\t2021-02-16T18:54:47Z\nv1.11.1\t\tv1.11.1\t2021-02-02T21:55:14Z\nv1.11.0\t\tv1.11.0\t2021-01-10T17:08:43Z\nv1.11.0-pre-gocloud\t\tv1.11.0-pre-gocloud\t2021-01-03T15:09:39Z\nv1.10.0\t\tv1.10.0\t2021-01-02T15:25:08Z\nv1.9.0\t\tv1.9.0\t2020-12-21T19:42:22Z\nv1.8.1\t\tv1.8.1\t2020-11-26T14:52:38Z\nv1.8.0\t\tv1.8.0\t2020-11-26T13:05:53Z\nv1.7.2\t\tv1.7.2\t2020-07-30T21:22:38Z\n",
 		null
-	],
-	"impure": true
+	  ],
+	  "impure": true
 	}
 ]`), func(ctx context.Context) {
 		context := &Context{
 			GoPath:               "/Users/myuser/go",
-			UpstreamProviderName: "terraform-provider-akamai",
+			UpstreamProviderName: "terraform-provider-postgresql",
 		}
 		result := getExpectedTargetLatest(context.Wrap(ctx),
-			repo, name)
+			upstreamOrg)
 		assert.NotNil(t, result)
-		assert.Nil(t, result.Version)
+
 	})
 }

--- a/upgrade/steps_helpers_test.go
+++ b/upgrade/steps_helpers_test.go
@@ -115,14 +115,14 @@ func TestPullRequestBody(t *testing.T) {
 }
 
 func TestGetExpectedTargetFromUpstream(t *testing.T) {
-	repo, name := "pulumi/pulumi-cloudflare", "cloudflare"
+	repo, upstreamOrg := "pulumi/pulumi-cloudflare", "cloudflare"
 
 	simpleReplay(t, jsonMarshal[[]*step.Step](t, `[
   {
     "name": "Get Expected Target",
     "inputs": [
       "`+repo+`",
-      "`+name+`"
+      "`+upstreamOrg+`"
     ],
     "outputs": [
       {
@@ -135,8 +135,7 @@ func TestGetExpectedTargetFromUpstream(t *testing.T) {
   {
     "name": "From Upstream Releases",
     "inputs": [
-      "pulumi/pulumi-cloudflare",
-      "cloudflare"
+      "`+upstreamOrg+`"
     ],
     "outputs": [
       {
@@ -170,7 +169,7 @@ func TestGetExpectedTargetFromUpstream(t *testing.T) {
 			UpstreamProviderName: "terraform-provider-cloudflare",
 		}
 		result := getExpectedTarget(context.Wrap(ctx),
-			repo, name)
+			repo, upstreamOrg)
 		assert.NotNil(t, result)
 	})
 }

--- a/upgrade/steps_helpers_test.go
+++ b/upgrade/steps_helpers_test.go
@@ -385,35 +385,3 @@ func TestExpectedTargetLatestBetaIgnored(t *testing.T) {
 		assert.Nil(t, result.Version)
 	})
 }
-
-func TestGetLatestErrorsOnNoRelease(t *testing.T) {
-
-	simpleReplay(t, jsonMarshal[[]*step.Step](t, `[
-{
-	"name": "gh",
-	"inputs": [
-		"gh",
-		[
-			"repo",
-			"view",
-			"akamai/terraform-provider-akamai",
-			"--json=latestRelease"
-		]
-	],
-	"outputs": [
-		"{\"latestRelease\":null}\n",
-		null
-	],
-	"impure": true
-	}
-]`), func(ctx context.Context) {
-		context := &Context{
-			GoPath:               "/Users/myuser/go",
-			UpstreamProviderName: "terraform-provider-akamai",
-		}
-		result, err := latestRelease(context.Wrap(ctx),
-			"akamai/terraform-provider-akamai")
-		assert.Nil(t, result)
-		assert.NotNil(t, err)
-	})
-}


### PR DESCRIPTION
See #218 for details.

Uses the full json repo info payload to determine the latest upstream release.

See https://github.com/pulumi/pulumi-minio/issues/251 for the fix applying to pulumi-minio specifically.

Fixes #218.
Fixes https://github.com/pulumi/pulumi-f5bigip/issues/345
Fixes https://github.com/pulumi/pulumi-venafi/issues/244


~**Reviewer Note**: This functionality overrides the changes in #226. Note that we're returning an empty UpgradeTargetVersion in the case of a non-stable release, so that the nil check on `Plan Provider Upgrade` reports that we are up to date. A `latest` version with a beta tag should not fail the upgrade process; we should ignore it.~
