### PR TITLE
Fix go path parsing

### DIFF
--- a/upgrade/kind.go
+++ b/upgrade/kind.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 	"golang.org/x/mod/modfile"
+	"golang.org/x/mod/module"
 
 	stepv2 "github.com/pulumi/upgrade-provider/step/v2"
 )
@@ -159,8 +160,12 @@ var getRepoKind = stepv2.Func11E("Get Repo Kind", func(ctx context.Context, repo
 		if replace.Old.Path != upstream.Mod.Path {
 			continue
 		}
+		hasMajorVersion := func(path string) bool {
+			_, major, ok := module.SplitPathVersion(path)
+			return ok && major != ""
+		}
 		before, after, found := strings.Cut(replace.New.Path, "/"+tfProviderRepoName)
-		if !found || (after != "" && !versionSuffix.MatchString(after)) {
+		if !found || (after != "" && !hasMajorVersion(after)) {
 			if replace.New.Path == "../upstream" {
 				// We have found a patched provider, so we can just exit here.
 				break

--- a/upgrade/steps_helpers.go
+++ b/upgrade/steps_helpers.go
@@ -8,7 +8,6 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"regexp"
 	"sort"
 	"strings"
 
@@ -20,11 +19,10 @@ import (
 	stepv2 "github.com/pulumi/upgrade-provider/step/v2"
 )
 
-var versionSuffix = regexp.MustCompile("/v[2-9][0-9]*$")
-
 func modPathWithoutVersion(path string) string {
-	if match := versionSuffix.FindStringIndex(path); match != nil {
-		return path[:match[0]]
+	withoutVersion, _, ok := module.SplitPathVersion(path)
+	if ok {
+		return withoutVersion
 	}
 	return path
 }
@@ -448,9 +446,7 @@ func getRepoExpectedLocation(ctx context.Context, cwd, repoPath string) (string,
 	}
 
 	// Strip version
-	if match := versionSuffix.FindStringIndex(repoPath); match != nil {
-		repoPath = repoPath[:match[0]]
-	}
+	repoPath = modPathWithoutVersion(repoPath)
 
 	repoPath, err := getGitHubPath(repoPath)
 	if err != nil {

--- a/upgrade/steps_helpers_test.go
+++ b/upgrade/steps_helpers_test.go
@@ -15,6 +15,37 @@ import (
 	"golang.org/x/mod/module"
 )
 
+func TestRemoveVersionPrefix(t *testing.T) {
+	t.Parallel()
+	tests := []struct{ input, expected string }{
+		{ // No mod path
+			"github.com/jfrog/terraform-provider-artifactory",
+			"github.com/jfrog/terraform-provider-artifactory",
+		},
+		{ // Single digit mod path
+			"github.com/jfrog/terraform-provider-artifactory/v4",
+			"github.com/jfrog/terraform-provider-artifactory",
+		},
+		{ // Multi-digit mod path (10)
+			"github.com/jfrog/terraform-provider-artifactory/v10",
+			"github.com/jfrog/terraform-provider-artifactory",
+		},
+		{ // Multi-digit mod path
+			"github.com/jfrog/terraform-provider-artifactory/v33",
+			"github.com/jfrog/terraform-provider-artifactory",
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.input, func(t *testing.T) {
+			actual := modPathWithoutVersion(tt.input)
+			assert.Equal(t, tt.expected, actual)
+		})
+	}
+
+}
+
 func TestGetRepoExpectedLocation(t *testing.T) {
 	ctx := &Context{
 		GoPath: "/Users/myuser/go",


### PR DESCRIPTION
We were failing to correctly parse /v10 since it started with 1. This replaces our regexp with module.SplitPathVersion.