### PR TITLE
Ignore beta releases

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -21,6 +21,8 @@ require (
 	github.com/hexops/autogold v1.3.1 // indirect
 	github.com/hexops/gotextdiff v1.0.3 // indirect
 	github.com/hexops/valast v1.4.4 // indirect
+	github.com/kr/pretty v0.3.1 // indirect
+	github.com/kr/text v0.2.0 // indirect
 	github.com/nightlyone/lockfile v1.0.0 // indirect
 	github.com/rogpeppe/go-internal v1.11.0 // indirect
 	gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c // indirect

--- a/go.mod
+++ b/go.mod
@@ -21,8 +21,6 @@ require (
 	github.com/hexops/autogold v1.3.1 // indirect
 	github.com/hexops/gotextdiff v1.0.3 // indirect
 	github.com/hexops/valast v1.4.4 // indirect
-	github.com/kr/pretty v0.3.1 // indirect
-	github.com/kr/text v0.2.0 // indirect
 	github.com/nightlyone/lockfile v1.0.0 // indirect
 	github.com/rogpeppe/go-internal v1.11.0 // indirect
 	gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c // indirect

--- a/upgrade/steps_helpers.go
+++ b/upgrade/steps_helpers.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"os"
 	"os/exec"

--- a/upgrade/steps_helpers.go
+++ b/upgrade/steps_helpers.go
@@ -529,7 +529,8 @@ var getExpectedTargetLatest = stepv2.Func21E("From Upstream Releases", func(ctx 
 		}
 		return &UpstreamUpgradeTarget{Version: v}, nil
 	}
-	return nil, errors.New("no releases found")
+	return nil, fmt.Errorf("no non-beta releases found in %s/%s",
+	upstreamOrg, GetContext(ctx).UpstreamProviderName)
 })
 
 // Figure out what version of upstream to target by looking at specific pulumi-bot

--- a/upgrade/steps_helpers.go
+++ b/upgrade/steps_helpers.go
@@ -509,6 +509,7 @@ var getExpectedTarget = stepv2.Func21("Get Expected Target", func(ctx context.Co
 // release.
 var getExpectedTargetLatest = stepv2.Func21E("From Upstream Releases", func(ctx context.Context,
 	name, upstreamOrg string) (*UpstreamUpgradeTarget, error) {
+	// TODO: use --json once https://github.com/cli/cli/issues/4572 is fixed
 	latest := stepv2.Cmd(ctx, "gh", "release", "list",
 		"--repo="+upstreamOrg+"/"+GetContext(ctx).UpstreamProviderName,
 		"--exclude-drafts",


### PR DESCRIPTION
Fixes https://github.com/pulumi/ci-mgmt/issues/749

When looking up the latest version of an upstream provider, we should skip beta releases.  
This PR achieves this by getting the list of the latest 30 releases and then iterating over them until it finds a non-beta release when looking up latest.