### PR TITLE
Enable 8-week release cadence

### DIFF
--- a/upgrade/steps.go
+++ b/upgrade/steps.go
@@ -267,7 +267,7 @@ var maintenanceRelease = stepv2.Func11E("Check if we should release a maintenanc
 	ctx context.Context,
 	repo ProviderRepo,
 ) (bool, error) {
-	repoWithOrg := repo.org + "/" + repo.name
+	repoWithOrg := repo.Org + "/" + repo.Name
 	// We ensure a release at least every 8-9 weeks, concurrent with a bridge update.
 	// There are 24 * 7 * 8 = 1344 hours in 8 weeks.
 	releaseCadence := time.Hour * 24 * 7 * 8
@@ -846,7 +846,7 @@ func migrationSteps(ctx context.Context, repo ProviderRepo, providerName string,
 }
 
 func AddAutoAliasing(ctx context.Context, repo ProviderRepo) (step.Step, error) {
-	providerName := strings.TrimPrefix(repo.name, "pulumi-")
+	providerName := strings.TrimPrefix(repo.Name, "pulumi-")
 	metadataPath := fmt.Sprintf("%s/cmd/pulumi-resource-%s/bridge-metadata.json", *repo.providerDir(), providerName)
 	steps := []step.Step{
 		step.F("ensure bridge-metadata.json", func(context.Context) (string, error) {
@@ -871,7 +871,7 @@ func AddAutoAliasing(ctx context.Context, repo ProviderRepo) (step.Step, error) 
 }
 
 func ReplaceAssertNoError(ctx context.Context, repo ProviderRepo) (step.Step, error) {
-	steps, err := migrationSteps(ctx, repo, repo.name, "Remove deprecated contract.Assert",
+	steps, err := migrationSteps(ctx, repo, repo.Name, "Remove deprecated contract.Assert",
 		AssertNoErrorMigration)
 	if err != nil {
 		return nil, err

--- a/upgrade/steps.go
+++ b/upgrade/steps.go
@@ -338,19 +338,19 @@ var InformGitHub = stepv2.Func70E("Inform Github", func(
 			"--body", prBody)
 	} else {
 		addLabels := []string{}
+
+		switch {
 		// We create release labels when we are running the full pulumi
 		// providers process: i.e. when we discovered issues to close at the
 		// beginning of the pipeline.
-		if c.UpgradeProviderVersion && len(target.GHIssues) > 0 {
+		case c.UpgradeProviderVersion && len(target.GHIssues) > 0:
 			label := upgradeLabel(ctx, repo.currentUpstreamVersion, target.Version)
 			if label != "" {
 				addLabels = []string{"--label", label}
 			}
-		}
-
 		// On non-upstream upgrades, we will create a patch release label
 		// if the provider hasn't been released in 8 weeks.
-		if c.MaintenancePatch && !c.UpgradeProviderVersion {
+		case c.MaintenancePatch && !c.UpgradeProviderVersion:
 			addLabels = []string{"--label", "needs-release/patch"}
 		}
 

--- a/upgrade/steps.go
+++ b/upgrade/steps.go
@@ -270,10 +270,7 @@ var maintenanceRelease = stepv2.Func10E("Check if we should release a maintenanc
 	repoWithOrg := repo.org + "/" + repo.name
 	// We ensure a release at least every 8-9 weeks, concurrent with a bridge update.
 	// There are 24 * 7 * 8 = 1344 hours in 8 weeks.
-	releaseCadence, err := time.ParseDuration("1344h")
-	if err != nil {
-		return err
-	}
+	releaseCadence := time.Hour * 24 * 7 * 8
 
 	relInfo, err := latestReleaseInfo(ctx, repoWithOrg)
 	if err != nil {
@@ -287,6 +284,7 @@ var maintenanceRelease = stepv2.Func10E("Check if we should release a maintenanc
 
 	stepv2.SetLabelf(ctx, "Last provider release date: %s", relInfo.Latest.PublishedAt)
 	ago := time.Since(releaseDate).Abs()
+
 	if ago > releaseCadence {
 		stepv2.SetLabelf(
 			ctx, "Last provider release date: %s. Marking for patch release.", relInfo.Latest.PublishedAt,

--- a/upgrade/steps_helpers.go
+++ b/upgrade/steps_helpers.go
@@ -9,6 +9,7 @@ import (
 	stepv2 "github.com/pulumi/upgrade-provider/step/v2"
 	"golang.org/x/mod/modfile"
 	"golang.org/x/mod/module"
+
 	"os"
 	"os/exec"
 	"path/filepath"

--- a/upgrade/steps_helpers.go
+++ b/upgrade/steps_helpers.go
@@ -4,17 +4,19 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"github.com/Masterminds/semver/v3"
-	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
-	stepv2 "github.com/pulumi/upgrade-provider/step/v2"
-	"golang.org/x/mod/modfile"
-	"golang.org/x/mod/module"
-
 	"os"
 	"os/exec"
 	"path/filepath"
 	"sort"
 	"strings"
+
+	"github.com/Masterminds/semver/v3"
+	"golang.org/x/mod/modfile"
+	"golang.org/x/mod/module"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
+
+	stepv2 "github.com/pulumi/upgrade-provider/step/v2"
 )
 
 func modPathWithoutVersion(path string) string {

--- a/upgrade/steps_helpers.go
+++ b/upgrade/steps_helpers.go
@@ -4,20 +4,16 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"github.com/Masterminds/semver/v3"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
+	stepv2 "github.com/pulumi/upgrade-provider/step/v2"
+	"golang.org/x/mod/modfile"
+	"golang.org/x/mod/module"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"sort"
 	"strings"
-	"time"
-
-	"github.com/Masterminds/semver/v3"
-	"golang.org/x/mod/modfile"
-	"golang.org/x/mod/module"
-
-	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
-
-	stepv2 "github.com/pulumi/upgrade-provider/step/v2"
 )
 
 func modPathWithoutVersion(path string) string {
@@ -440,21 +436,6 @@ var latestReleaseVersion = stepv2.Func11E("Latest Release Version",
 			stepv2.SetLabelf(ctx, "of %s: %s", repo, v)
 		}
 		return v, err
-	})
-
-var latestReleaseDate = stepv2.Func11E("Latest Release Date",
-	func(ctx context.Context, repo string) (time.Time, error) {
-		stepv2.SetLabelf(ctx, "of %s", repo)
-		rel, err := latestReleaseInfo(ctx, repo)
-		if err != nil {
-			return time.Time{}, err //TODO": make this better
-		}
-		stepv2.SetLabelf(ctx, "%s published at %s", repo, rel.Latest.PublishedAt)
-		date, err := time.Parse(time.RFC3339, rel.Latest.PublishedAt)
-		if err == nil {
-			stepv2.SetLabelf(ctx, "of %s: %s", repo, date)
-		}
-		return time.Parse(time.RFC3339, rel.Latest.PublishedAt)
 	})
 
 // getRepoExpectedLocation will return one of the following:

--- a/upgrade/steps_test.go
+++ b/upgrade/steps_test.go
@@ -293,7 +293,8 @@ func TestCheckMaintenancePatchWithinCadence(t *testing.T) {
             {}
           ],
           "outputs": [
-            null
+            false,
+			null
           ]
         },
         {
@@ -323,8 +324,8 @@ func TestCheckMaintenancePatchWithinCadence(t *testing.T) {
 			name: "pulumi-cloudinit",
 		}
 
-		maintenanceRelease(context.Wrap(ctx), repo)
-		assert.False(t, context.MaintenancePatch)
+		result := maintenanceRelease(context.Wrap(ctx), repo)
+		assert.NotNil(t, result)
 	})
 }
 
@@ -337,6 +338,7 @@ func TestCheckMaintenancePatchExpiredCadence(t *testing.T) {
             {}
           ],
           "outputs": [
+			true,
             null
           ]
         },
@@ -367,7 +369,7 @@ func TestCheckMaintenancePatchExpiredCadence(t *testing.T) {
 			name: "pulumi-cloudinit",
 		}
 
-		maintenanceRelease(context.Wrap(ctx), repo)
-		assert.True(t, context.MaintenancePatch)
+		result := maintenanceRelease(context.Wrap(ctx), repo)
+		assert.NotNil(t, result)
 	})
 }

--- a/upgrade/steps_test.go
+++ b/upgrade/steps_test.go
@@ -286,11 +286,17 @@ func TestParseUpstreamProviderOrgFromModVersion(t *testing.T) {
 }
 func TestCheckMaintenancePatchWithinCadence(t *testing.T) {
 
-	simpleReplay(t, jsonMarshal[[]*step.Step](t, `[
+	testReplay((&Context{
+		GoPath: "/Users/myuser/go",
+	}).Wrap(context.Background()),
+		t, jsonMarshal[[]*step.Step](t, `[
 	{
           "name": "Check if we should release a maintenance patch",
           "inputs": [
-            {}
+            {
+				"Org":  "pulumi",
+				"Name": "pulumi-cloudinit"
+			}
           ],
           "outputs": [
             false,
@@ -314,32 +320,26 @@ func TestCheckMaintenancePatchWithinCadence(t *testing.T) {
           ],
           "impure": true
         }
-]`), func(ctx context.Context) {
-		context := &Context{
-			GoPath: "/Users/myuser/go",
-		}
-
-		repo := ProviderRepo{
-			org:  "pulumi",
-			name: "pulumi-cloudinit",
-		}
-
-		result := maintenanceRelease(context.Wrap(ctx), repo)
-		assert.NotNil(t, result)
-	})
+]`), "Check if we should release a maintenance patch", maintenanceRelease)
 }
 
 func TestCheckMaintenancePatchExpiredCadence(t *testing.T) {
 
-	simpleReplay(t, jsonMarshal[[]*step.Step](t, `[
+	testReplay((&Context{
+		GoPath: "/Users/myuser/go",
+	}).Wrap(context.Background()),
+		t, jsonMarshal[[]*step.Step](t, `[
 	{
           "name": "Check if we should release a maintenance patch",
           "inputs": [
-            {}
+            {
+				"Org":  "pulumi",
+				"Name": "pulumi-cloudinit"
+			}
           ],
           "outputs": [
-			true,
-            null
+            true,
+			null
           ]
         },
         {
@@ -354,22 +354,9 @@ func TestCheckMaintenancePatchExpiredCadence(t *testing.T) {
             ]
           ],
           "outputs": [
-            "{\"latestRelease\":{\"name\":\"v1.4.0\",\"tagName\":\"v1.4.0\",\"url\":\"https://github.com/pulumi/pulumi-cloudinit/releases/tag/v1.4.0\",\"publishedAt\":\"2023-01-04T21:03:48Z\"}}\n",
-            null
+			"{\"latestRelease\":{\"name\":\"v1.4.0\",\"tagName\":\"v1.4.0\",\"url\":\"https://github.com/pulumi/pulumi-cloudinit/releases/tag/v1.4.0\",\"publishedAt\":\"2023-01-04T21:03:48Z\"}}\n",            null
           ],
           "impure": true
         }
-]`), func(ctx context.Context) {
-		context := &Context{
-			GoPath: "/Users/myuser/go",
-		}
-
-		repo := ProviderRepo{
-			org:  "pulumi",
-			name: "pulumi-cloudinit",
-		}
-
-		result := maintenanceRelease(context.Wrap(ctx), repo)
-		assert.NotNil(t, result)
-	})
+]`), "Check if we should release a maintenance patch", maintenanceRelease)
 }

--- a/upgrade/steps_test.go
+++ b/upgrade/steps_test.go
@@ -323,8 +323,7 @@ func TestCheckMaintenancePatchWithinCadence(t *testing.T) {
 			name: "pulumi-cloudinit",
 		}
 
-		maintenanceRelease(context.Wrap(ctx),
-			repo)
+		maintenanceRelease(context.Wrap(ctx), repo)
 		assert.False(t, context.MaintenancePatch)
 	})
 }
@@ -368,8 +367,7 @@ func TestCheckMaintenancePatchExpiredCadence(t *testing.T) {
 			name: "pulumi-cloudinit",
 		}
 
-		maintenanceRelease(context.Wrap(ctx),
-			repo)
+		maintenanceRelease(context.Wrap(ctx), repo)
 		assert.True(t, context.MaintenancePatch)
 	})
 }

--- a/upgrade/testdata/replay/kong_existing_pr.json
+++ b/upgrade/testdata/replay/kong_existing_pr.json
@@ -112,7 +112,10 @@
           "name": "Inform Github",
           "inputs": [
             null,
-            {},
+            {
+              "Org": "",
+              "Name":"pulumi/pulumi-kong"
+            },
             {
               "Kind": "plain",
               "Upstream": {

--- a/upgrade/testdata/replay/wavefront_inform_github.json
+++ b/upgrade/testdata/replay/wavefront_inform_github.json
@@ -12,9 +12,13 @@
                 {
                   "number": 232
                 }
+
               ]
             },
-            {},
+            {
+              "Org": "",
+              "Name":"pulumi/pulumi-wavefront"
+            },
             {
               "Kind": "plain",
               "Upstream": {

--- a/upgrade/upgrade_provider.go
+++ b/upgrade/upgrade_provider.go
@@ -102,6 +102,8 @@ func UpgradeProvider(ctx context.Context, repoOrg, repoName string) (err error) 
 		if GetContext(ctx).UpgradeBridgeVersion {
 			targetBridgeVersion = planBridgeUpgrade(ctx, goMod)
 			tfSDKTargetSHA, tfSDKUpgrade = planPluginSDKUpgrade(ctx, repo)
+			// Check if we need to release a maintenance patch
+			maintenanceRelease(ctx, repo)
 		}
 
 		if GetContext(ctx).UpgradePfVersion {

--- a/upgrade/upgrade_provider.go
+++ b/upgrade/upgrade_provider.go
@@ -38,8 +38,8 @@ func UpgradeProvider(ctx context.Context, repoOrg, repoName string) (err error) 
 	}
 
 	repo := ProviderRepo{
-		name: repoName,
-		org:  repoOrg,
+		Name: repoName,
+		Org:  repoOrg,
 	}
 	var targetBridgeVersion, targetPfVersion Ref
 	var tfSDKUpgrade string
@@ -170,7 +170,7 @@ func UpgradeProvider(ctx context.Context, repoOrg, repoName string) (err error) 
 	var forkedProviderUpstreamCommit string
 	if goMod.Kind.IsForked() && GetContext(ctx).UpgradeProviderVersion {
 		err := stepv2.PipelineCtx(ctx, "Upgrade Forked Provider", func(ctx context.Context) {
-			upgradeUpstreamFork(ctx, repo.name, upgradeTarget.Version, goMod)
+			upgradeUpstreamFork(ctx, repo.Name, upgradeTarget.Version, goMod)
 		})
 		if err != nil {
 			return err

--- a/upgrade/upgrade_provider.go
+++ b/upgrade/upgrade_provider.go
@@ -102,8 +102,8 @@ func UpgradeProvider(ctx context.Context, repoOrg, repoName string) (err error) 
 		if GetContext(ctx).UpgradeBridgeVersion {
 			targetBridgeVersion = planBridgeUpgrade(ctx, goMod)
 			tfSDKTargetSHA, tfSDKUpgrade = planPluginSDKUpgrade(ctx, repo)
-			// Check if we need to release a maintenance patch
-			maintenanceRelease(ctx, repo)
+			// Check if we need to release a maintenance patch and set context if so
+			GetContext(ctx).MaintenancePatch = maintenanceRelease(ctx, repo)
 		}
 
 		if GetContext(ctx).UpgradePfVersion {

--- a/upgrade/upgrade_test.go
+++ b/upgrade/upgrade_test.go
@@ -36,7 +36,7 @@ func TestInformGithub(t *testing.T) {
 			}, ProviderRepo{
 				workingBranch:          "upgrade-terraform-provider-wavefront-to-v5.0.5",
 				defaultBranch:          "master",
-				name:                   "pulumi/pulumi-wavefront",
+				Name:                   "pulumi/pulumi-wavefront",
 				currentUpstreamVersion: semver.MustParse("5.0.3"),
 			}, &GoMod{
 				Kind: "plain",
@@ -69,7 +69,7 @@ func TestInformGithubExistingPR(t *testing.T) {
 			nil, ProviderRepo{
 				workingBranch:   "upgrade-pulumi-terraform-bridge-to-v3.62.0",
 				defaultBranch:   "master",
-				name:            "pulumi/pulumi-kong",
+				Name:            "pulumi/pulumi-kong",
 				prAlreadyExists: true,
 			}, &GoMod{
 				Kind: "plain",

--- a/upgrade/util.go
+++ b/upgrade/util.go
@@ -125,8 +125,8 @@ type ProviderRepo struct {
 	// are go module compliment, we might not be able to always resolve this version.
 	currentUpstreamVersion *semver.Version
 
-	name string
-	org  string
+	Name string
+	Org  string
 }
 
 func (p ProviderRepo) providerDir() *string {

--- a/upgrade/util.go
+++ b/upgrade/util.go
@@ -40,10 +40,9 @@ type Context struct {
 
 	UpgradeJavaVersion bool
 
-	// We want to regularly patch a provider with bridge and vulnerability updates, even if there is no upstream release.
-	// During a bridge upgrade, which happens at least weekly,  if it has been more than 8 weeks since the latest
-	// release of this provider, this field will be set to True and a patch release will be triggered.
-	// patch release will be triggered on the
+	// Some providers go for months without an upstream release, but do receive weekly bridge updates.
+	// upgrade-provider will detect if the provider's last release is more than eight weeks old, and if it is,
+	// setting this field to True will trigger a patch release on a non-upstream upgrade.
 	MaintenancePatch bool
 
 	// The unqualified name of the upstream provider.

--- a/upgrade/util.go
+++ b/upgrade/util.go
@@ -40,6 +40,12 @@ type Context struct {
 
 	UpgradeJavaVersion bool
 
+	// We want to regularly patch a provider with bridge and vulnerability updates, even if there is no upstream release.
+	// During a bridge upgrade, which happens at least weekly,  if it has been more than 8 weeks since the latest
+	// release of this provider, this field will be set to True and a patch release will be triggered.
+	// patch release will be triggered on the
+	MaintenancePatch bool
+
 	// The unqualified name of the upstream provider.
 	//
 	// As an example, Pulumi's AWS provider has:


### PR DESCRIPTION
Prior to this change, all provider releases via this tool only occurred on upstream upgrades. This meant that security and codegen/bridge updates would merge to the default branch, but wait on an upstream release to apply to the provider, potentially resulting in a provider using an ancient version of the bridge.

This pull request sets a maximum ~8-week release cadence for all providers.

During a bridge update, we check if we have released the provider in question within the last 8 weeks.
If we have not, and the upgrade is a non-upstream upgrade, we will add a `needs-release/patch` label to the bridge update pull request.

Doing this will result in more frequent upgrades, ensuring our providers use a recent bridge and pulumi version.

One detail to call out:
- We may choose to set the release cadence to 7 weeks, to ensure we "catch" the update at minimum every 8th week; this PR sets it to 8 weeks exactly.
- We can also count actual bridge releases if we do not want to use time comparisons.

Fixes https://github.com/pulumi/ci-mgmt/issues/726.