### PR TITLE
Add `CallWithReplay` to `step/v2`

### DIFF
--- a/step/v2/replay.go
+++ b/step/v2/replay.go
@@ -357,8 +357,7 @@ func CallWithReplay(ctx context.Context, pipeline, fnName string, f any) error {
 		r.t.Fatalf("Cannot call %q for replay: %[1]q is impure", fnName)
 	}
 
-	inputs := make([]any, fType.NumIn()-1) // Excluding the mandatory context.Context
-
+	var inputs []any
 	err := json.Unmarshal(step.Inputs, &inputs)
 	if err != nil {
 		r.t.Fatalf("Failed to unmarshal step %q args: %s", fnName, err.Error())

--- a/step/v2/replay.go
+++ b/step/v2/replay.go
@@ -298,7 +298,14 @@ func (r *record) Marshal() []byte {
 
 type recordKey struct{}
 
-// Mark the calling context as an impure function.
+// Mark the calling context as an impure step.
+//
+// This library defines an "impure step" as any step which is not "pure". A "pure" step is
+// a side-effect free mapping from it's inputs to it's outputs. Contrary to the common
+// definition of a pure function, step purity is not transitive, so a "pure step" may call
+// an impure step.
+//
+// At a practical level, replay tests mock impure functions, while calling pure functions.
 //
 // Note: Impure functions must have serializable inputs and outputs for replay testing.
 func MarkImpure(ctx context.Context) {
@@ -328,17 +335,17 @@ func getReplay(ctx context.Context) *Replay {
 	return nil
 }
 
-// Call the function f (named name) that was created with step.FuncXY on the arguments
+// Call the function f (named stepName) that was created with step.FuncXY on the arguments
 // that the replay associated with ctx has recorded.
 //
 // This function will panic if f cannot be called. This may be because:
 //
 // - f is impure.
-// - name could not be found in the current replay.
-// - CallWithReplay could not fit the found arguments from name to f.
+// - stepName could not be found in the current replay.
+// - CallWithReplay could not fit the found arguments from stepName to f.
 //
 // It is expected that this function is used only in tests.
-func CallWithReplay(ctx context.Context, pipeline, fnName string, f any) error {
+func CallWithReplay(ctx context.Context, pipeline, stepName string, f any) error {
 	r := *getReplay(ctx) // Don't mutate the replay
 
 	r.setPipeline(pipeline)
@@ -348,19 +355,19 @@ func CallWithReplay(ctx context.Context, pipeline, fnName string, f any) error {
 		r.t.Fatalf("f must be a func")
 	}
 
-	stepN := r.findNextStep(fnName)
+	stepN := r.findNextStep(stepName)
 	if stepN == -1 {
-		r.t.Fatalf("Could not find replay for %q to call", fnName)
+		r.t.Fatalf("Could not find replay for %q to call", stepName)
 	}
 	step := r.steps[stepN]
 	if step.Impure {
-		r.t.Fatalf("Cannot call %q for replay: %[1]q is impure", fnName)
+		r.t.Fatalf("Cannot call %q for replay: %[1]q is impure", stepName)
 	}
 
 	var inputs []any
 	err := json.Unmarshal(step.Inputs, &inputs)
 	if err != nil {
-		r.t.Fatalf("Failed to unmarshal step %q args: %s", fnName, err.Error())
+		r.t.Fatalf("Failed to unmarshal step %q args: %s", stepName, err.Error())
 	}
 
 	// Perform a type-correcting unmarshal from inputs to inputs.
@@ -369,7 +376,7 @@ func CallWithReplay(ctx context.Context, pipeline, fnName string, f any) error {
 	err = hydrateTo(inputs, inputs,
 		func(i int) reflect.Type { return fType.In(i + 1) })
 	if err != nil {
-		r.t.Fatalf("Failed to hydrate step %s args: %s", fnName, err.Error())
+		r.t.Fatalf("Failed to hydrate step %s args: %s", stepName, err.Error())
 	}
 
 	return PipelineCtx(ctx, pipeline, func(ctx context.Context) {

--- a/step/v2/replay.go
+++ b/step/v2/replay.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"reflect"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -315,10 +316,69 @@ func MarkImpure(ctx context.Context) {
 }
 
 func IsReplay(ctx context.Context) bool {
+	return getReplay(ctx) != nil
+}
+
+func getReplay(ctx context.Context) *Replay {
 	for _, v := range getEnvs(ctx) {
-		if _, ok := v.(*Replay); ok {
-			return true
+		if r, ok := v.(*Replay); ok {
+			return r
 		}
 	}
-	return false
+	return nil
+}
+
+// Call the function f (named name) that was created with step.FuncXY on the arguments
+// that the replay associated with ctx has recorded.
+//
+// This function will panic if f cannot be called. This may be because:
+//
+// - f is impure.
+// - name could not be found in the current replay.
+// - CallWithReplay could not fit the found arguments from name to f.
+//
+// It is expected that this function is used only in tests.
+func CallWithReplay(ctx context.Context, pipeline, fnName string, f any) error {
+	r := *getReplay(ctx) // Don't mutate the replay
+
+	r.setPipeline(pipeline)
+
+	fType := reflect.TypeOf(f)
+	if fType.Kind() != reflect.Func {
+		r.t.Fatalf("f must be a func")
+	}
+
+	stepN := r.findNextStep(fnName)
+	if stepN == -1 {
+		r.t.Fatalf("Could not find replay for %q to call", fnName)
+	}
+	step := r.steps[stepN]
+	if step.Impure {
+		r.t.Fatalf("Cannot call %q for replay: %[1]q is impure", fnName)
+	}
+
+	inputs := make([]any, fType.NumIn()-1) // Excluding the mandatory context.Context
+
+	err := json.Unmarshal(step.Inputs, &inputs)
+	if err != nil {
+		r.t.Fatalf("Failed to unmarshal step %q args: %s", fnName, err.Error())
+	}
+
+	// Perform a type-correcting unmarshal from inputs to inputs.
+	//
+	// inputs[1:] since we want to skip the initial context.Context.
+	err = hydrateTo(inputs, inputs,
+		func(i int) reflect.Type { return fType.In(i + 1) })
+	if err != nil {
+		r.t.Fatalf("Failed to hydrate step %s args: %s", fnName, err.Error())
+	}
+
+	return PipelineCtx(ctx, pipeline, func(ctx context.Context) {
+		callValues := make([]reflect.Value, fType.NumIn())
+		callValues[0] = reflect.ValueOf(ctx)
+		for i := 0; i < len(inputs); i++ {
+			callValues[i+1] = reflect.ValueOf(inputs[i])
+		}
+		reflect.ValueOf(f).Call(callValues)
+	})
 }

--- a/step/v2/replay.go
+++ b/step/v2/replay.go
@@ -373,7 +373,7 @@ func CallWithReplay(ctx context.Context, pipeline, stepName string, f any) error
 	// Perform a type-correcting unmarshal from inputs to inputs.
 	//
 	// inputs[1:] since we want to skip the initial context.Context.
-	err = hydrateTo(inputs, inputs,
+	inputs, err = hydrateTo(inputs,
 		func(i int) reflect.Type { return fType.In(i + 1) })
 	if err != nil {
 		r.t.Fatalf("Failed to hydrate step %s args: %s", stepName, err.Error())

--- a/step/v2/step_test.go
+++ b/step/v2/step_test.go
@@ -125,3 +125,68 @@ func testCastNonNil[T any](t *testing.T, expected T) {
 		assert.Equal(t, expected, actual)
 	})
 }
+
+func TestHydrateTo(t *testing.T) {
+	t.Parallel()
+
+	type demoStruct struct {
+		Foo int
+		Bar string
+	}
+
+	tests := []struct {
+		src      []any
+		types    []reflect.Type
+		expected []any
+	}{
+		{
+			[]any{"string", "foo"},
+			[]reflect.Type{reflect.TypeOf(""), reflect.TypeOf("")},
+			[]any{"string", "foo"},
+		},
+		{
+			[]any{nil},
+			[]reflect.Type{reflect.TypeOf(map[string]testing.T{})},
+			[]any{map[string]testing.T(nil)},
+		},
+		{
+			[]any{map[string]any{"foo": 3, "bar": "fizz"}},
+			[]reflect.Type{reflect.TypeOf(demoStruct{})},
+			[]any{demoStruct{
+				Foo: 3,
+				Bar: "fizz",
+			}},
+		},
+		{
+			[]any{3, map[string]any{"foo": 3, "bar": "fizz"}, nil},
+			[]reflect.Type{
+				reflect.TypeOf(float64(0)),
+				reflect.TypeOf(demoStruct{}),
+				reflect.TypeOf(""),
+			},
+			[]any{
+				float64(3),
+				demoStruct{
+					Foo: 3,
+					Bar: "fizz",
+				},
+				"",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run("", func(t *testing.T) {
+			t.Parallel()
+
+			idxType := func(i int) reflect.Type {
+				return tt.types[i]
+			}
+			dst, err := hydrateTo(tt.src, idxType)
+			if assert.NoError(t, err) {
+				assert.Equal(t, tt.expected, dst)
+			}
+		})
+	}
+}

--- a/upgrade/steps_helpers_test.go
+++ b/upgrade/steps_helpers_test.go
@@ -118,7 +118,7 @@ func TestPullRequestBody(t *testing.T) {
 func TestGetExpectedTargetFromUpstream(t *testing.T) {
 	repo := "pulumi/pulumi-cloudflare"
 
-	simpleReplay((&Context{
+	testReplay((&Context{
 		GoPath:               "/Users/myuser/go",
 		UpstreamProviderName: "terraform-provider-cloudflare",
 		UpstreamProviderOrg:  "cloudflare",
@@ -180,7 +180,7 @@ func TestGetExpectedTargetFromTarget(t *testing.T) {
 				InferVersion:         inferVersion,
 				TargetVersion:        semver.MustParse(targetVersion),
 			}).Wrap(context.Background())
-			simpleReplay(ctx, t, expectedSteps,
+			testReplay(ctx, t, expectedSteps,
 				"Get Expected Target", getExpectedTarget)
 		})
 	}
@@ -287,7 +287,7 @@ func TestExpectedTargetLatest(t *testing.T) {
 		UpstreamProviderOrg:  "akamai",
 	}).Wrap(context.Background())
 
-	simpleReplay(ctx, t, jsonMarshal[[]*step.Step](t, `[
+	testReplay(ctx, t, jsonMarshal[[]*step.Step](t, `[
 	{
 	  "name": "From Upstream Releases",
 	  "inputs": [],
@@ -327,7 +327,7 @@ func TestFromUpstreamReleasesBetaIgnored(t *testing.T) {
 		UpstreamProviderOrg:  "cyrilgdn",
 	}).Wrap(context.Background())
 
-	simpleReplay(ctx, t, jsonMarshal[[]*step.Step](t, `[
+	testReplay(ctx, t, jsonMarshal[[]*step.Step](t, `[
 	{
 	  "name": "From Upstream Releases",
 	  "inputs": [],

--- a/upgrade/steps_test.go
+++ b/upgrade/steps_test.go
@@ -112,7 +112,7 @@ func TestHasRemoteBranch(t *testing.T) {
 				return json.RawMessage(b)
 			}
 
-			simpleReplay(context.Background(), t, []*step.Step{
+			testReplay(context.Background(), t, []*step.Step{
 				{
 					Name:    "Has Remote Branch",
 					Inputs:  encode([]string{tt.branchName}),
@@ -203,7 +203,7 @@ func TestEnsureBranchCheckedOut(t *testing.T) {
 				replay = replay[:len(replay)-1]
 			}
 
-			simpleReplay(context.Background(), t, replay,
+			testReplay(context.Background(), t, replay,
 				"Ensure Branch", ensureBranchCheckedOut)
 		})
 	}

--- a/upgrade/steps_test.go
+++ b/upgrade/steps_test.go
@@ -264,7 +264,7 @@ func TestReleaseLabel(t *testing.T) {
 }
 
 func TestParseUpstreamProviderOrgFromModVersion(t *testing.T) {
-	simpleReplay((&Context{
+	testReplay((&Context{
 		GoPath:               "/Users/myuser/go",
 		UpstreamProviderName: "terraform-provider-datadog",
 		UpstreamProviderOrg:  "",

--- a/upgrade/steps_test.go
+++ b/upgrade/steps_test.go
@@ -213,12 +213,8 @@ func TestEnsureBranchCheckedOut(t *testing.T) {
 
 func TestEnsureUpstreamRepo(t *testing.T) {
 	ctx := newReplay(t, "download_aiven")
-	err := step.PipelineCtx(ctx, "Discover Provider", func(ctx context.Context) {
-		ctx = (&Context{
-			GoPath: "/goPath",
-		}).Wrap(ctx)
-		ensureUpstreamRepo(ctx, "github.com/pulumi/pulumi-aiven")
-	})
+	err := step.CallWithReplay((&Context{GoPath: "/goPath"}).Wrap(ctx), "Discover Provider",
+		"Ensure Upstream Repo", ensureUpstreamRepo)
 	require.NoError(t, err)
 }
 

--- a/upgrade/upgrade_test.go
+++ b/upgrade/upgrade_test.go
@@ -99,23 +99,8 @@ func TestBridgeUpgradeNoop(t *testing.T) {
 		UpstreamProviderOrg:  "hashicorp",
 	}).Wrap(ctx)
 
-	err := step.PipelineCtx(ctx, "Plan Upgrade", func(ctx context.Context) {
-		planBridgeUpgrade(ctx, &GoMod{
-			Kind: Patched,
-			Pf: module.Version{
-				Path:    "github.com/pulumi/pulumi-terraform-bridge/pf",
-				Version: "v0.23.0",
-			},
-			Bridge: module.Version{
-				Path:    "github.com/pulumi/pulumi-terraform-bridge/v3",
-				Version: "v3.70.0",
-			},
-			Upstream: module.Version{
-				Path:    "github.com/hashicorp/terraform-provider-google-beta",
-				Version: "v0.0.0",
-			},
-		})
-	})
+	err := step.CallWithReplay(ctx, "Plan Upgrade",
+		"Planning Bridge Upgrade", planBridgeUpgrade)
 	require.NoError(t, err)
 
 	assert.False(t, GetContext(ctx).UpgradeBridgeVersion)

--- a/upgrade/upgrade_test.go
+++ b/upgrade/upgrade_test.go
@@ -120,7 +120,7 @@ func readFile(t *testing.T, path string) []byte {
 	return bytes
 }
 
-func simpleReplay(ctx context.Context, t *testing.T, stepReplay []*step.Step, fName string, f any) {
+func testReplay(ctx context.Context, t *testing.T, stepReplay []*step.Step, fName string, f any) {
 	bytes, err := json.Marshal(step.ReplayV1{
 		Pipelines: []step.RecordV1{{
 			Name:  t.Name(),

--- a/upgrade/upgrade_test.go
+++ b/upgrade/upgrade_test.go
@@ -120,7 +120,7 @@ func readFile(t *testing.T, path string) []byte {
 	return bytes
 }
 
-func simpleReplay(t *testing.T, stepReplay []*step.Step, f func(context.Context)) {
+func simpleReplay(ctx context.Context, t *testing.T, stepReplay []*step.Step, fName string, f any) {
 	bytes, err := json.Marshal(step.ReplayV1{
 		Pipelines: []step.RecordV1{{
 			Name:  t.Name(),
@@ -130,9 +130,9 @@ func simpleReplay(t *testing.T, stepReplay []*step.Step, f func(context.Context)
 	require.NoError(t, err)
 
 	r := step.NewReplay(t, bytes)
-	ctx := step.WithEnv(context.Background(), r)
+	ctx = step.WithEnv(ctx, r)
 
-	err = step.PipelineCtx(ctx, t.Name(), f)
+	err = step.CallWithReplay(ctx, t.Name(), fName, f)
 	assert.NoError(t, err)
 }
 


### PR DESCRIPTION
Add a new testing helper: `CallWithReplay`.

This helper calls a `step/v2` function replay (identified by pipeline and name) with the arguments recorded in the replay. This makes it much less cumbersome to write and update replay based tests, since test code longer needs to include an identical copy of initial arguments.

Caveats: `CallWithReplay` imposes the additional requirement that the initial function inputs can be deserialized from JSON. Replay functionality already requires that inputs can be serialized to JSON, so this isn't a big stretch.
