### PR TITLE
Get upstream org from goMod object

### DIFF
--- a/upgrade/steps.go
+++ b/upgrade/steps.go
@@ -182,7 +182,7 @@ func UpgradeProviderVersion(
 		// If they are versioning correctly, `go mod tidy` will resolve the SHA to a tag.
 		steps = append(steps,
 			step.F("Lookup Tag SHA", func(context.Context) (string, error) {
-				upstreamOrg := GetContext(ctx).UpstreamProviderOrg
+				upstreamOrg := goMod.UpstreamProviderOrg
 				upstreamRepo := GetContext(ctx).UpstreamProviderName
 				gitHostPath := "https://github.com/" + upstreamOrg + "/" + upstreamRepo
 


### PR DESCRIPTION
We were reading the upstream org from a place where we didn't set it.
