### PR TITLE
Enable gci linter with automatic fix. Apply lint fixes.

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,13 @@
+linters:
+  enable:
+    - gci
+
+linters-settings:
+  gci:
+    sections:
+      - standard # Standard section: captures all standard packages.
+      - blank # Blank section: contains all blank imports.
+      - default # Default section: contains all imports that could not be matched to another section type.
+      - prefix(github.com/pulumi/) # Custom section: groups all imports with the github.com/pulumi/ prefix.
+      - prefix(github.com/pulumi/upgrade-provider) # Custom section: local imports
+    custom-order: true

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,10 @@ install:
 	go install github.com/pulumi/upgrade-provider
 
 lint:
-	golangci-lint run -E gci --fix
+	golangci-lint run
+
+lint.fix:
+	golangci-lint run --fix
 
 test:
 	go test -v ./...

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ install:
 	go install github.com/pulumi/upgrade-provider
 
 lint:
-	golangci-lint run
+	golangci-lint run -E gci --fix
 
 test:
 	go test -v ./...

--- a/main.go
+++ b/main.go
@@ -9,12 +9,14 @@ import (
 	"strings"
 
 	semver "github.com/Masterminds/semver/v3"
-	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
-	"github.com/pulumi/upgrade-provider/colorize"
-	"github.com/pulumi/upgrade-provider/upgrade"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
+
+	"github.com/pulumi/upgrade-provider/colorize"
+	"github.com/pulumi/upgrade-provider/upgrade"
 )
 
 const (

--- a/main.go
+++ b/main.go
@@ -10,12 +10,11 @@ import (
 
 	semver "github.com/Masterminds/semver/v3"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
+	"github.com/pulumi/upgrade-provider/colorize"
+	"github.com/pulumi/upgrade-provider/upgrade"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
-
-	"github.com/pulumi/upgrade-provider/colorize"
-	"github.com/pulumi/upgrade-provider/upgrade"
 )
 
 const (

--- a/step/v2/util_test.go
+++ b/step/v2/util_test.go
@@ -7,9 +7,10 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/pulumi/upgrade-provider/step/v2"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/pulumi/upgrade-provider/step/v2"
 )
 
 func TestWithCwd(t *testing.T) {

--- a/upgrade/kind.go
+++ b/upgrade/kind.go
@@ -7,10 +7,9 @@ import (
 	"strings"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
+	stepv2 "github.com/pulumi/upgrade-provider/step/v2"
 	"golang.org/x/mod/modfile"
 	"golang.org/x/mod/module"
-
-	stepv2 "github.com/pulumi/upgrade-provider/step/v2"
 )
 
 type RepoKind string

--- a/upgrade/kind.go
+++ b/upgrade/kind.go
@@ -6,10 +6,12 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
-	stepv2 "github.com/pulumi/upgrade-provider/step/v2"
 	"golang.org/x/mod/modfile"
 	"golang.org/x/mod/module"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
+
+	stepv2 "github.com/pulumi/upgrade-provider/step/v2"
 )
 
 type RepoKind string

--- a/upgrade/kind_test.go
+++ b/upgrade/kind_test.go
@@ -2,11 +2,12 @@ package upgrade
 
 import (
 	"context"
+	"testing"
+
 	"github.com/pulumi/upgrade-provider/step/v2"
 	"github.com/stretchr/testify/assert"
 	"golang.org/x/mod/modfile"
 	"golang.org/x/mod/module"
-	"testing"
 )
 
 func TestGetUpstreamProviderOrgFromConfig(t *testing.T) {

--- a/upgrade/kind_test.go
+++ b/upgrade/kind_test.go
@@ -4,10 +4,11 @@ import (
 	"context"
 	"testing"
 
-	"github.com/pulumi/upgrade-provider/step/v2"
 	"github.com/stretchr/testify/assert"
 	"golang.org/x/mod/modfile"
 	"golang.org/x/mod/module"
+
+	"github.com/pulumi/upgrade-provider/step/v2"
 )
 
 func TestGetUpstreamProviderOrgFromConfig(t *testing.T) {

--- a/upgrade/migrations.go
+++ b/upgrade/migrations.go
@@ -11,9 +11,8 @@ import (
 	"os"
 	"strings"
 
-	"golang.org/x/tools/go/ast/astutil"
-
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
+	"golang.org/x/tools/go/ast/astutil"
 )
 
 const (

--- a/upgrade/migrations.go
+++ b/upgrade/migrations.go
@@ -11,8 +11,9 @@ import (
 	"os"
 	"strings"
 
-	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 	"golang.org/x/tools/go/ast/astutil"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 )
 
 const (

--- a/upgrade/steps.go
+++ b/upgrade/steps.go
@@ -18,14 +18,13 @@ import (
 
 	semver "github.com/Masterminds/semver/v3"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
+	"github.com/pulumi/upgrade-provider/colorize"
+	"github.com/pulumi/upgrade-provider/step"
+	stepv2 "github.com/pulumi/upgrade-provider/step/v2"
 	"golang.org/x/mod/modfile"
 	"golang.org/x/mod/module"
 	goSemver "golang.org/x/mod/semver"
 	"gopkg.in/yaml.v3"
-
-	"github.com/pulumi/upgrade-provider/colorize"
-	"github.com/pulumi/upgrade-provider/step"
-	stepv2 "github.com/pulumi/upgrade-provider/step/v2"
 )
 
 // A "git commit" step that is resilient to no changes in the directory.

--- a/upgrade/steps.go
+++ b/upgrade/steps.go
@@ -17,14 +17,16 @@ import (
 	"strings"
 
 	semver "github.com/Masterminds/semver/v3"
-	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
-	"github.com/pulumi/upgrade-provider/colorize"
-	"github.com/pulumi/upgrade-provider/step"
-	stepv2 "github.com/pulumi/upgrade-provider/step/v2"
 	"golang.org/x/mod/modfile"
 	"golang.org/x/mod/module"
 	goSemver "golang.org/x/mod/semver"
 	"gopkg.in/yaml.v3"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
+
+	"github.com/pulumi/upgrade-provider/colorize"
+	"github.com/pulumi/upgrade-provider/step"
+	stepv2 "github.com/pulumi/upgrade-provider/step/v2"
 )
 
 // A "git commit" step that is resilient to no changes in the directory.

--- a/upgrade/steps_helpers.go
+++ b/upgrade/steps_helpers.go
@@ -12,10 +12,9 @@ import (
 
 	"github.com/Masterminds/semver/v3"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
+	stepv2 "github.com/pulumi/upgrade-provider/step/v2"
 	"golang.org/x/mod/modfile"
 	"golang.org/x/mod/module"
-
-	stepv2 "github.com/pulumi/upgrade-provider/step/v2"
 )
 
 func modPathWithoutVersion(path string) string {

--- a/upgrade/steps_helpers.go
+++ b/upgrade/steps_helpers.go
@@ -11,10 +11,12 @@ import (
 	"strings"
 
 	"github.com/Masterminds/semver/v3"
-	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
-	stepv2 "github.com/pulumi/upgrade-provider/step/v2"
 	"golang.org/x/mod/modfile"
 	"golang.org/x/mod/module"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
+
+	stepv2 "github.com/pulumi/upgrade-provider/step/v2"
 )
 
 func modPathWithoutVersion(path string) string {

--- a/upgrade/steps_helpers_test.go
+++ b/upgrade/steps_helpers_test.go
@@ -10,9 +10,10 @@ import (
 
 	"github.com/Masterminds/semver/v3"
 	"github.com/hexops/autogold/v2"
-	"github.com/pulumi/upgrade-provider/step/v2"
 	"github.com/stretchr/testify/assert"
 	"golang.org/x/mod/module"
+
+	"github.com/pulumi/upgrade-provider/step/v2"
 )
 
 func TestRemoveVersionPrefix(t *testing.T) {

--- a/upgrade/steps_test.go
+++ b/upgrade/steps_test.go
@@ -8,9 +8,10 @@ import (
 	"testing"
 
 	"github.com/Masterminds/semver/v3"
-	"github.com/pulumi/upgrade-provider/step/v2"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/pulumi/upgrade-provider/step/v2"
 )
 
 func TestGetWorkingBranch(t *testing.T) {

--- a/upgrade/upgrade_test.go
+++ b/upgrade/upgrade_test.go
@@ -8,10 +8,11 @@ import (
 	"testing"
 
 	"github.com/Masterminds/semver/v3"
-	"github.com/pulumi/upgrade-provider/step/v2"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/mod/module"
+
+	"github.com/pulumi/upgrade-provider/step/v2"
 )
 
 func TestInformGithub(t *testing.T) {

--- a/upgrade/util.go
+++ b/upgrade/util.go
@@ -48,9 +48,9 @@ type Context struct {
 	//
 	UpstreamProviderName string
 	// The org component in the upstream provider's repo path.
-	// 
-	// This must be provided when upstream is hosted at a repo that does 
-	// not match the Go Module path it is declared as. Otherwise it can 
+	//
+	// This must be provided when upstream is hosted at a repo that does
+	// not match the Go Module path it is declared as. Otherwise it can
 	// be inferred.
 	//
 	// For example, if we have an upstream provider with import path:
@@ -62,7 +62,7 @@ type Context struct {
 	//	github.com/my-org/terraform-provider-my-provider
 	//
 	// Then UpstreamProviderOrg should be `my-org`.
-	UpstreamProviderOrg  string
+	UpstreamProviderOrg string
 
 	// The desired version of pulumi/{pkg,sdk} to link to.
 	//


### PR DESCRIPTION
If we want to standardize import grouping and sorting, we should enforce it in code.
