### PR TITLE
allow only upgrading pulumi

### DIFF
--- a/main.go
+++ b/main.go
@@ -129,6 +129,7 @@ func cmd() *cobra.Command {
 					set(&context.UpgradeCodeMigration)
 				case "pf":
 					set(&context.UpgradePfVersion)
+				case "pulumi":
 				case "check-upstream-version":
 					if targetVersion != "" {
 						return fmt.Errorf(
@@ -140,7 +141,7 @@ func cmd() *cobra.Command {
 
 				default:
 					return fmt.Errorf(
-						"--kind=%s invalid. Must be one of `all`, `bridge`, `provider`, `code`, or `pf`",
+						"--kind=%s invalid. Must be one of `all`, `bridge`, `provider`, `code`, `pf`, or `pulumi`",
 						upgradeKind)
 				}
 			}


### PR DESCRIPTION
This adds a kind to only upgrade the pulumi version.

This is used by pulumi/pulumi to run downstream codegen tests and the PRs should not be merged.

Part of https://github.com/pulumi/pulumi/issues/15140