### PR TITLE
Fail fast on --kind empty

### DIFF
--- a/main.go
+++ b/main.go
@@ -101,9 +101,8 @@ func cmd() *cobra.Command {
 
 			// This can happen by calling `upgrade-provider --kind=""`
 			if len(upgradeKind) == 0 {
-				return fmt.Errorf(
-					"--kind=\"\" is invalid. Must be one of `all`, `bridge`, `provider`, `code`, `pf`, or `pulumi`",
-					upgradeKind)
+				return fmt.Errorf("--kind=\"\" is invalid. Must be one of `all`, " +
+					"`bridge`, `provider`, `code`, `pf`, or `pulumi`")
 			}
 
 			// Validate the kind switch

--- a/main.go
+++ b/main.go
@@ -99,6 +99,13 @@ func cmd() *cobra.Command {
 				}
 			}
 
+			// This can happen by calling `upgrade-provider --kind=""`
+			if len(upgradeKind) == 0 {
+				return fmt.Errorf(
+					"--kind=\"\" is invalid. Must be one of `all`, `bridge`, `provider`, `code`, `pf`, or `pulumi`",
+					upgradeKind)
+			}
+
 			// Validate the kind switch
 			var warnedAll bool
 			for _, kind := range upgradeKind {


### PR DESCRIPTION
Before the change `upgrade provider --kind=""` would proceed with "No changes required" success message. I believe it is better to fail fast. 