### PR TITLE
Fix planning SDK update when bridge does not change

### DIFF
--- a/upgrade/steps.go
+++ b/upgrade/steps.go
@@ -963,6 +963,11 @@ var planProviderUpgrade = stepv2.Func41E("Plan Provider Upgrade", func(ctx conte
 	return upgradeTarget, nil
 })
 
+// If a bridge update is needed, will return the concrete Ref (never returns "latest").
+//
+// If the bridge is up to date, will return nil and unset the following flag:
+//
+//     GetContext(ctx).UpgradeBridgeVersion = false
 var planBridgeUpgrade = stepv2.Func11E("Planning Bridge Upgrade", func(
 	ctx context.Context, goMod *GoMod,
 ) (Ref, error) {

--- a/upgrade/steps.go
+++ b/upgrade/steps.go
@@ -967,7 +967,7 @@ var planProviderUpgrade = stepv2.Func41E("Plan Provider Upgrade", func(ctx conte
 //
 // If the bridge is up to date, will return nil and unset the following flag:
 //
-//     GetContext(ctx).UpgradeBridgeVersion = false
+//	GetContext(ctx).UpgradeBridgeVersion = false
 var planBridgeUpgrade = stepv2.Func11E("Planning Bridge Upgrade", func(
 	ctx context.Context, goMod *GoMod,
 ) (Ref, error) {

--- a/upgrade/upgrade_provider.go
+++ b/upgrade/upgrade_provider.go
@@ -100,7 +100,10 @@ func UpgradeProvider(ctx context.Context, repoOrg, repoName string) (err error) 
 	err = stepv2.PipelineCtx(ctx, "Plan Upgrade", func(ctx context.Context) {
 		if GetContext(ctx).UpgradeBridgeVersion {
 			targetBridgeVersion = planBridgeUpgrade(ctx, goMod)
-			tfSDKTargetSHA, tfSDKUpgrade = planPluginSDKUpgrade(ctx, targetBridgeVersion.String())
+			if targetBridgeVersion != nil {
+				tbv := targetBridgeVersion.String()
+				tfSDKTargetSHA, tfSDKUpgrade = planPluginSDKUpgrade(ctx, tbv)
+			}
 			// Check if we need to release a maintenance patch and set context if so
 			GetContext(ctx).MaintenancePatch = maintenanceRelease(ctx, repo)
 		}


### PR DESCRIPTION
Quick fix for a panic introduced in https://github.com/pulumi/upgrade-provider/issues/243

Would like to merge to prevent p1s, follow up with tests later.

Verified this works on pulumi-azuread.
