### PR TITLE
Hard code upstream module versions

### DIFF
--- a/upgrade/upgrade_provider.go
+++ b/upgrade/upgrade_provider.go
@@ -223,35 +223,6 @@ func UpgradeProvider(ctx context.Context, repoOrg, repoName string) (err error) 
 			setTFPluginSDKReplace(ctx, repo, &tfSDKTargetSHA),
 			step.Cmd("go", "mod", "tidy").In(repo.providerDir()))
 
-		// replaceTFMuxAndPluginGo := step.F("Replace tf module versions", func(ctx context.Context) (string, error) {
-		// 	content, err := os.ReadFile("go.mod")
-		// 	if err != nil {
-		// 		return "", err
-		// 	}
-
-		// 	pluginGoStr := "github.com/hashicorp/terraform-plugin-go v0.%s.0 // indirect"
-		// 	oldPluginGoStr := fmt.Sprintf(pluginGoStr, "22")
-		// 	newPluginGoStr := fmt.Sprintf(pluginGoStr, "21")
-
-		// 	muxStr := "github.com/hashicorp/terraform-plugin-mux v0.%s.0 // indirect"
-		// 	oldMuxStr := fmt.Sprintf(muxStr, "15")
-		// 	newMuxStr := fmt.Sprintf(muxStr, "14")
-
-		// 	modifiedContent := strings.Replace(string(content), oldPluginGoStr, newPluginGoStr, -1)
-		// 	modifiedContent = strings.Replace(modifiedContent, oldMuxStr, newMuxStr, -1)
-
-		// 	err = os.WriteFile("go.mod", []byte(modifiedContent), 0)
-		// 	if err != nil {
-		// 		return "", err
-		// 	}
-		// 	return "", nil
-		// }).In(repo.providerDir())
-
-		// steps = append(steps,
-		// 	replaceTFMuxAndPluginGo,
-		// 	step.Cmd("go", "mod", "tidy").In(repo.providerDir()),
-		// )
-
 		return step.Combined("Update Plugin SDK", steps...)
 	}))
 

--- a/upgrade/upgrade_provider.go
+++ b/upgrade/upgrade_provider.go
@@ -223,6 +223,35 @@ func UpgradeProvider(ctx context.Context, repoOrg, repoName string) (err error) 
 			setTFPluginSDKReplace(ctx, repo, &tfSDKTargetSHA),
 			step.Cmd("go", "mod", "tidy").In(repo.providerDir()))
 
+		// replaceTFMuxAndPluginGo := step.F("Replace tf module versions", func(ctx context.Context) (string, error) {
+		// 	content, err := os.ReadFile("go.mod")
+		// 	if err != nil {
+		// 		return "", err
+		// 	}
+
+		// 	pluginGoStr := "github.com/hashicorp/terraform-plugin-go v0.%s.0 // indirect"
+		// 	oldPluginGoStr := fmt.Sprintf(pluginGoStr, "22")
+		// 	newPluginGoStr := fmt.Sprintf(pluginGoStr, "21")
+
+		// 	muxStr := "github.com/hashicorp/terraform-plugin-mux v0.%s.0 // indirect"
+		// 	oldMuxStr := fmt.Sprintf(muxStr, "15")
+		// 	newMuxStr := fmt.Sprintf(muxStr, "14")
+
+		// 	modifiedContent := strings.Replace(string(content), oldPluginGoStr, newPluginGoStr, -1)
+		// 	modifiedContent = strings.Replace(modifiedContent, oldMuxStr, newMuxStr, -1)
+
+		// 	err = os.WriteFile("go.mod", []byte(modifiedContent), 0)
+		// 	if err != nil {
+		// 		return "", err
+		// 	}
+		// 	return "", nil
+		// }).In(repo.providerDir())
+
+		// steps = append(steps,
+		// 	replaceTFMuxAndPluginGo,
+		// 	step.Cmd("go", "mod", "tidy").In(repo.providerDir()),
+		// )
+
 		return step.Combined("Update Plugin SDK", steps...)
 	}))
 
@@ -242,7 +271,9 @@ func UpgradeProvider(ctx context.Context, repoOrg, repoName string) (err error) 
 			step.Cmd("go", "get",
 				"github.com/pulumi/pulumi-terraform-bridge/v3@"+targetBridgeVersion.String()),
 			step.Cmd("go", "get", "github.com/hashicorp/terraform-plugin-framework"),
-			step.Cmd("go", "get", "github.com/hashicorp/terraform-plugin-mux"),
+			// Hard-code the versions here until https://github.com/pulumi/pulumi-terraform-bridge/issues/1704 is resolved
+			step.Cmd("go", "get", "github.com/hashicorp/terraform-plugin-mux@v0.14.0"),
+			step.Cmd("go", "get", "github.com/hashicorp/terraform-plugin-go@v0.21.0"),
 			step.Cmd("go", "mod", "tidy"),
 		).In(repo.providerDir()))
 	}


### PR DESCRIPTION
Should work around https://github.com/pulumi/pulumi-terraform-bridge/issues/1704 until plugin-framework releases a compatible version.

Tested in https://github.com/pulumi/pulumi-gcp/pull/1718