### PR TITLE
Add needs release arg

### DIFF
--- a/main.go
+++ b/main.go
@@ -256,6 +256,8 @@ This is equivalent to setting PULUMI_MISSING_DOCS_ERROR=${! VALUE}.`)
 	cmd.PersistentFlags().StringVar(&context.PRTitlePrefix, "pr-title-prefix", "",
 		`The prefix to insert in the generated pull request title.`)
 
+	cmd.PersistentFlags().BoolVar(&context.NeedsReleasePatch, "needs-release-patch", false, "setting this field to True will trigger a patch release after the PR is merged.")
+
 	return cmd
 }
 

--- a/upgrade/steps.go
+++ b/upgrade/steps.go
@@ -345,7 +345,11 @@ var InformGitHub = stepv2.Func70E("Inform Github", func(
 			}
 		// On non-upstream upgrades, we will create a patch release label
 		// if the provider hasn't been released in 8 weeks.
-		case c.MaintenancePatch && !c.UpgradeProviderVersion:
+		case (c.MaintenancePatch && !c.UpgradeProviderVersion):
+			addLabels = []string{"--label", "needs-release/patch"}
+
+		// If we have the needs release flag, we make a patch release.
+		case c.NeedsReleasePatch:
 			addLabels = []string{"--label", "needs-release/patch"}
 		}
 

--- a/upgrade/util.go
+++ b/upgrade/util.go
@@ -91,6 +91,8 @@ type Context struct {
 
 	PRDescription string
 	PRTitlePrefix string
+
+	NeedsReleasePatch bool
 }
 
 func (c *Context) Wrap(ctx context.Context) context.Context {


### PR DESCRIPTION
This can be used to trigger releases of all providers on a bridge release.