### PR TITLE
Suffix major version upgrade branches with `-major`

### DIFF
--- a/upgrade/steps.go
+++ b/upgrade/steps.go
@@ -516,6 +516,8 @@ var getWorkingBranch = stepv2.Func41E("Working Branch Name", func(ctx context.Co
 	}
 
 	switch {
+	case c.MajorVersionBump:
+		return ret("upgrade-%s-to-v%s-major", c.UpstreamProviderName, upgradeTarget.Version)
 	case c.UpgradeProviderVersion:
 		return ret("upgrade-%s-to-v%s", c.UpstreamProviderName, upgradeTarget.Version)
 	case c.UpgradeBridgeVersion:


### PR DESCRIPTION
This allows our CI automation adjust the version number it generates to match the expected version prefix.

Related to https://github.com/pulumi/provider-version-action/pull/7