### PR TITLE
Handle tag objects when tags are listed for remote repos

### DIFF
--- a/upgrade/steps_helpers.go
+++ b/upgrade/steps_helpers.go
@@ -360,6 +360,14 @@ func setUpstreamFromRemoteRepo(
 		// characters, but its **very** unlikely.
 		line = strings.Split(line, "\t")[1]
 		versionComponent := strings.TrimPrefix(string(line), "refs/"+kind+"/")
+		// From the gitrevisions(7) Manual Page:
+		//
+		//	<rev>^{}, e.g. v0.99.8^{}
+		//
+		//	A suffix ^ followed by an empty brace pair means the object could
+		//	be a tag, and dereference the tag recursively until a non-tag
+		//	object is found.
+		versionComponent = strings.TrimSuffix(versionComponent, "^{}")
 		version, err := parse(versionComponent)
 		if err != nil {
 			// Its possible that this error is valid, for example if the tag has a path,


### PR DESCRIPTION
Correctly handle tag objects when parsing upstream semver tags.

This is very similar to what we do for patched providers:

https://github.com/pulumi/upgrade-provider/blob/b625b8f79e1e57d625bbc31aadaefc380a917c16/upgrade/steps_helpers.go#L276

Fixes https://github.com/pulumi/pulumi-nomad/issues/398