### PR TITLE
Clear examples cache during major upgrades

### DIFF
--- a/upgrade/steps.go
+++ b/upgrade/steps.go
@@ -673,6 +673,9 @@ var majorVersionBump = stepv2.Func30("Increment Major Version", func(
 	setEnv(ctx, "VERSION_PREFIX", nextMajorVersion)
 
 	addVersionPrefixToGHWorkflows(ctx, repo, nextMajorVersion)
+
+	// Remove examples cache
+	stepv2.Cmd(ctx, "rm", "-rf", ".pulumi/examples-cache")
 })
 
 // Build a replace function that converts finds instances of `replace` and converts


### PR DESCRIPTION
Update: Apologies for the delay here; see https://github.com/pulumi/pulumi-terraform-bridge/issues/2323.

https://github.com/pulumi/pulumi-confluentcloud/pull/559 failed because the upgrade process was using an old examples cache locally.
As a result, the Go SDK was generated with old version paths in the examples code, which failed the Clean Worktree check.
The upgrade-provider tool should remove the cache to ensure we're generating examples correctly.