### PR TITLE
Permit skipping Git pull operations

### DIFF
--- a/main.go
+++ b/main.go
@@ -175,7 +175,7 @@ func cmd() *cobra.Command {
 	contract.AssertNoErrorf(err, "could not mark `upgrade-java` flag as hidden")
 
 	cmd.PersistentFlags().StringVar(&repoPath, "repo-path", "",
-		`Clone the provider repo to the specified path.`)
+		`Clone the provider repo to the specified path. Skip cloning if set to "."`)
 
 	cmd.PersistentFlags().StringVar(&targetVersion, "target-version", "",
 		`Upgrade the provider to the passed version.

--- a/upgrade/steps_helpers.go
+++ b/upgrade/steps_helpers.go
@@ -253,7 +253,11 @@ var setCurrentUpstreamFromPatched = stepv2.Func10E("Set Upstream From Patched", 
 		return fmt.Errorf("found empty SHA")
 	}
 
-	stepv2.Cmd(ctx, "git", "submodule", "init")
+	// If the user set --repo-path as CWD, do not init the submodules as this is assumed to have been done.
+	if GetContext(ctx).repoPath != "." {
+		stepv2.Cmd(ctx, "git", "submodule", "init")
+	}
+
 	remoteURL := strings.TrimSpace(stepv2.Cmd(ctx,
 		"git", "config", "--get", "submodule.upstream.url"))
 

--- a/upgrade/steps_helpers.go
+++ b/upgrade/steps_helpers.go
@@ -254,7 +254,7 @@ var setCurrentUpstreamFromPatched = stepv2.Func10E("Set Upstream From Patched", 
 	}
 
 	// If the user set --repo-path as CWD, do not init the submodules as this is assumed to have been done.
-	if GetContext(ctx).repoPath != "." {
+	if !GetContext(ctx).IsCWD() {
 		stepv2.Cmd(ctx, "git", "submodule", "init")
 	}
 

--- a/upgrade/upgrade_provider.go
+++ b/upgrade/upgrade_provider.go
@@ -65,7 +65,7 @@ func UpgradeProvider(ctx context.Context, repoOrg, repoName string) (err error) 
 		repo.root = OrgProviderRepos(ctx, repoOrg, repoName)
 		// If the user set --repo-path as CWD, assume all git content is already in-place; simply infer the main
 		// branch without pulling anything. Otherwise, pull.
-		if GetContext(ctx).repoPath == "." {
+		if GetContext(ctx).IsCWD() {
 			repo.defaultBranch = findDefaultBranch(ctx, "origin")
 		} else {
 			repo.defaultBranch = pullDefaultBranch(ctx, "origin")

--- a/upgrade/upgrade_provider.go
+++ b/upgrade/upgrade_provider.go
@@ -63,7 +63,13 @@ func UpgradeProvider(ctx context.Context, repoOrg, repoName string) (err error) 
 
 	err = stepv2.PipelineCtx(ctx, "Discover Provider", func(ctx context.Context) {
 		repo.root = OrgProviderRepos(ctx, repoOrg, repoName)
-		repo.defaultBranch = pullDefaultBranch(ctx, "origin")
+		// If the user set --repo-path as CWD, assume all git content is already in-place; simply infer the main
+		// branch without pulling anything. Otherwise, pull.
+		if GetContext(ctx).repoPath == "." {
+			repo.defaultBranch = findDefaultBranch(ctx, "origin")
+		} else {
+			repo.defaultBranch = pullDefaultBranch(ctx, "origin")
+		}
 		goMod = getRepoKind(ctx, repo)
 
 		// If we do not have the upstream provider org set in the .upgrade-config.yml, we infer it from the go mod path.

--- a/upgrade/util.go
+++ b/upgrade/util.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/Masterminds/semver/v3"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 	"golang.org/x/mod/modfile"
 	"golang.org/x/mod/module"
 )
@@ -91,6 +92,19 @@ type Context struct {
 
 	PRDescription string
 	PRTitlePrefix string
+}
+
+// Check if the user specified operating in the current working directory (CWD) with `--repo-path=.`. In this case the
+// tool can assume all Git fetching and sumbodule resolution has been done already by the user.
+func (c *Context) IsCWD() bool {
+	if c.repoPath == "" {
+		return false
+	}
+	cwd, err := filepath.Abs(".")
+	contract.AssertNoErrorf(err, "filepath.Abs failed unexpectedly")
+	rp, err := filepath.Abs(c.repoPath)
+	contract.AssertNoErrorf(err, "filepath.Abs failed unexpectedly")
+	return cwd == rp
 }
 
 func (c *Context) Wrap(ctx context.Context) context.Context {

--- a/upgrade/util.go
+++ b/upgrade/util.go
@@ -6,9 +6,10 @@ import (
 	"strings"
 
 	"github.com/Masterminds/semver/v3"
-	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 	"golang.org/x/mod/modfile"
 	"golang.org/x/mod/module"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 )
 
 type contextKeyType struct{}


### PR DESCRIPTION
In https://github.com/pulumi/pulumi-aws/issues/4427 the checkout action is fighting with upgrade-provider on the subtleties of checking out submodules. This PR makes it possible to use upgrade-provider with a pre-fetched repo:

    upgrade-provider ... --repo-path .

This will now resist from pulling or working with submodules. I have used this script to test the change; this emulates the steps that GitHub actions are using to fetch a shallow copy of pulumi-aws in actions/checkout:

    #!/usr/bin/env bash

    set -euo pipefail

    rm -rf /tmp/aws
    mkdir /tmp/aws
    pushd /tmp/aws
    git init
    git remote add origin https://github.com/pulumi/pulumi-aws
    git -c protocol.version=2 fetch --no-tags --prune --no-recurse-submodules --depth=1 origin +3ff4fa4ddc54bcef6d043e7c62e0e881c6ecdaa5:refs/remotes/origin/master
    git checkout --progress --force -B master refs/remotes/origin/master
    git submodule sync
    git -c protocol.version=2 submodule update --init --force --depth=1
    ls
    git status
    popd

    go build
    B="$PWD/upgrade-provider"

    (cd /tmp/aws && "$B" "pulumi/pulumi-aws" --kind=check-upstream-version --repo-path=.)