### PR TITLE
Don't require issues to be opened by pulumi-bot

### DIFF
--- a/upgrade/steps_helpers_test.go
+++ b/upgrade/steps_helpers_test.go
@@ -273,14 +273,14 @@ func TestGetExpectedTargetFromTarget(t *testing.T) {
         "issue",
         "list",
         "--state=open",
-        "--author=pulumi-bot",
         "--repo=pulumi/pulumi-cloudflare",
         "--limit=100",
-        "--json=title,number"
+        "--search=\"Upgrade terraform-provider- to\"",
+        "--json=title,number,author"
       ]
     ],
     "outputs": [
-      "[{\"number\":540,\"title\":\"Upgrade terraform-provider-cloudflare to v2.32.0\"},{\"number\":538,\"title\":\"Upgrade terraform-provider-cloudflare to v2.31.0\"}]\n",
+      "[{\"number\":540,\"title\":\"Upgrade terraform-provider-cloudflare to v2.32.0\",\"author\":{\"login\":\"pulumi-bot\"}},{\"number\":538,\"title\":\"Upgrade terraform-provider-cloudflare to v2.31.0\",\"author\":{\"login\":\"app/github-actions\"}}]\n",
       null
     ],
     "impure": true


### PR DESCRIPTION
As we move to using the built-in GitHub actions app to create issues this would have to be filtered via either `--author=pulumi-bot` or `--app=github-actions`.

Instead, we'll filter server-side by a simple text match query, then filter on author being pulumi-bot or github-actions via a client-side check.

Side note: this code will also break if anyone runs with `--kind=check-upstream-version` locally as issues will be created with their own github user account.