### PR TITLE
Allow upgrade-provider to be run outside of CI

### DIFF
--- a/upgrade/steps_helpers.go
+++ b/upgrade/steps_helpers.go
@@ -722,11 +722,14 @@ var createUpstreamUpgradeIssue = stepv2.Func30E("Ensure Upstream Issue", func(ct
 func upgradeIssueExits(ctx context.Context, title, repoOrg, repoName string) (bool, error) {
 	var found bool
 	var err error
-	// Search through existing "pulumiupgradeproviderissue" issues to see if we've already created one for this version.
+	// TODO: Remove this after we've migrated all issues to the new format.
+	// https://github.com/pulumi/upgrade-provider/issues/284
+	// Fall back to searching through the issues from the current user.
 	found, err = issueExistsForVersion(ctx, title,
 		fmt.Sprintf("--repo=%q", repoOrg+"/"+repoName),
-		fmt.Sprintf("--search=%q", upgradeIssueBodyTemplate),
-		"--state=open")
+		fmt.Sprintf("--search=%q", title),
+		"--state=open",
+		"--author=@me")
 	if err != nil {
 		return false, err
 	}
@@ -734,12 +737,11 @@ func upgradeIssueExits(ctx context.Context, title, repoOrg, repoName string) (bo
 		return true, nil
 	}
 
-	// Fall back to searching through the issues from the current user.
+	// Search through existing pulumiupgradeproviderissue issues to see if we've already created one for this version.
 	found, err = issueExistsForVersion(ctx, title,
 		fmt.Sprintf("--repo=%q", repoOrg+"/"+repoName),
-		fmt.Sprintf("--search=%q", title),
-		"--state=open",
-		"--author=@me")
+		fmt.Sprintf("--search=%q", upgradeIssueBodyTemplate),
+		"--state=open")
 	if err != nil {
 		return false, err
 	}


### PR DESCRIPTION
Filtering via @me assumes that the user is always the same when creating issues. This might not be true if a user runs this tool locally. This also breaks when the author is an app such as github-actions as this must be specified via the `--app` option instead of `--author`.

As an alternative approach, GitHub will index for search any word within the issue body, even hidden within an HTML comment. We'll include the word "pulumiupgradeproviderissue" in the HTML comment to allow listing all upgrade issues easily via search. Once we've listed candidate issues, we'll check client-side for an exact matching title.

Here's an example issue where I've manually added this hidden comment to test searching:
- https://github.com/pulumi/pulumi-aws/issues/4652

![Issue description preview](https://github.com/user-attachments/assets/cc57dc0c-8bad-41d2-8c1b-b0ffb5f097ff)

We'll leave the existing "@me" based search in as a fallback until we can be confident that these tokens will be present in relevant issues.

Resolves #280 