### PR TITLE
Simplify identifying provider upgrade issues

### DIFF
--- a/upgrade/steps_helpers.go
+++ b/upgrade/steps_helpers.go
@@ -621,13 +621,10 @@ var getExpectedTargetFromIssues = stepv2.Func11E("From Issues", func(ctx context
 		"--repo="+name,
 		"--limit=100",
 		fmt.Sprintf("--search=%q", upgradeIssueToken),
-		"--json=title,number,author")
+		"--json=title,number")
 	titles := []struct {
 		Title  string `json:"title"`
 		Number int    `json:"number"`
-		Author struct {
-			Login string `json:"login"`
-		} `json:"author"`
 	}{}
 	err := json.Unmarshal([]byte(issueList), &titles)
 	if err != nil {
@@ -636,11 +633,6 @@ var getExpectedTargetFromIssues = stepv2.Func11E("From Issues", func(ctx context
 
 	var upgradeTargetIssues []UpgradeTargetIssue
 	for _, title := range titles {
-		isPulumiBot := title.Author.Login == "pulumi-bot"
-		isGitHubActions := title.Author.Login == "app/github-actions"
-		if !isPulumiBot && !isGitHubActions {
-			continue
-		}
 		_, nameToVersion, found := strings.Cut(title.Title, "Upgrade terraform-provider-")
 		if !found {
 			continue

--- a/upgrade/steps_helpers.go
+++ b/upgrade/steps_helpers.go
@@ -620,7 +620,7 @@ var getExpectedTargetFromIssues = stepv2.Func11E("From Issues", func(ctx context
 		"--state=open",
 		"--repo="+name,
 		"--limit=100",
-		"--search=\"Upgrade terraform-provider- to\"",
+		fmt.Sprintf("--search=%q", upgradeIssueToken),
 		"--json=title,number,author")
 	titles := []struct {
 		Title  string `json:"title"`

--- a/upgrade/steps_helpers.go
+++ b/upgrade/steps_helpers.go
@@ -672,6 +672,7 @@ var getExpectedTargetFromIssues = stepv2.Func11E("From Issues", func(ctx context
 })
 
 // Hide searchable token in the issue body via an HTML comment to help us find this issue later without requiring labels to be set up.
+const upgradeIssueToken = "pulumiupgradeproviderissue"
 const upgradeIssueBodyTemplate = `
 <!-- for upgrade-provider issue searching: pulumiupgradeproviderissue -->
 
@@ -723,7 +724,7 @@ func upgradeIssueExits(ctx context.Context, title, repoOrg, repoName string) (bo
 	// Search through existing pulumiupgradeproviderissue issues to see if we've already created one for this version.
 	issues, err := searchIssues(ctx,
 		fmt.Sprintf("--repo=%s", repoOrg+"/"+repoName),
-		fmt.Sprintf("--search=%q", upgradeIssueBodyTemplate),
+		fmt.Sprintf("--search=%q", upgradeIssueToken),
 		"--state=open")
 	if err != nil {
 		return false, err

--- a/upgrade/steps_helpers.go
+++ b/upgrade/steps_helpers.go
@@ -634,7 +634,7 @@ var getExpectedTargetFromIssues = stepv2.Func11E("From Issues", func(ctx context
 		return nil, err
 	}
 
-	var versions []UpgradeTargetIssue
+	var upgradeTargetIssues []UpgradeTargetIssue
 	for _, title := range titles {
 		isPulumiBot := title.Author.Login == "pulumi-bot"
 		isGitHubActions := title.Author.Login == "app/github-actions"
@@ -653,21 +653,21 @@ var getExpectedTargetFromIssues = stepv2.Func11E("From Issues", func(ctx context
 		if err != nil {
 			continue
 		}
-		versions = append(versions, UpgradeTargetIssue{
+		upgradeTargetIssues = append(upgradeTargetIssues, UpgradeTargetIssue{
 			Version: v,
 			Number:  title.Number,
 		})
 	}
-	if len(versions) == 0 {
+	if len(upgradeTargetIssues) == 0 {
 		return nil, nil
 	}
-	sort.Slice(versions, func(i, j int) bool {
-		return versions[j].Version.LessThan(versions[i].Version)
+	sort.Slice(upgradeTargetIssues, func(i, j int) bool {
+		return upgradeTargetIssues[j].Version.LessThan(upgradeTargetIssues[i].Version)
 	})
 
 	return &UpstreamUpgradeTarget{
-		Version:  versions[0].Version,
-		GHIssues: versions,
+		Version:  upgradeTargetIssues[0].Version,
+		GHIssues: upgradeTargetIssues,
 	}, nil
 })
 

--- a/upgrade/steps_helpers_test.go
+++ b/upgrade/steps_helpers_test.go
@@ -275,8 +275,8 @@ func TestGetExpectedTargetFromTarget(t *testing.T) {
         "--state=open",
         "--repo=pulumi/pulumi-cloudflare",
         "--limit=100",
-        "--search=\"Upgrade terraform-provider- to\"",
-        "--json=title,number,author"
+        "--search=\"pulumiupgradeproviderissue\"",
+        "--json=title,number"
       ]
     ],
     "outputs": [


### PR DESCRIPTION
1. Use search token for finding issues to close
2. Rename variable  - name variable after the type.
3. Remove checking author when finding issues 
   - Now we're using the token for search it's a lot more reliable so we can remove the additional filtering.

Stacked on #287 