### PR TITLE
Make assignee optional

### DIFF
--- a/main.go
+++ b/main.go
@@ -236,7 +236,7 @@ plugins are used if existing versions are present in the cache.`)
 	cmd.PersistentFlags().StringVar(&context.PrReviewers, "pr-reviewers", "",
 		`A comma separated list of reviewers to assign the upgrade PR to.`)
 
-	cmd.PersistentFlags().StringVar(&context.PrAssign, "pr-assign", "@me",
+	cmd.PersistentFlags().StringVar(&context.PrAssign, "pr-assign", "",
 		`A user to assign the upgrade PR to.`)
 
 	cmd.PersistentFlags().BoolVarP(&context.AllowMissingDocs, "allow-missing-docs", "", false,

--- a/upgrade/testdata/replay/wavefront_inform_github.json
+++ b/upgrade/testdata/replay/wavefront_inform_github.json
@@ -12,12 +12,11 @@
                 {
                   "number": 232
                 }
-
               ]
             },
             {
               "Org": "",
-              "Name":"pulumi/pulumi-wavefront"
+              "Name": "pulumi/pulumi-wavefront"
             },
             {
               "Kind": "plain",
@@ -82,8 +81,6 @@
             [
               "pr",
               "create",
-              "--assignee",
-              "@me",
               "--base",
               "master",
               "--head",


### PR DESCRIPTION
PRs and issues can't be assigned to apps, so the default of "@me" will break when being run by the built-in GitHub Actions app from CI when we migrate away from using the single central pulumi-bot account. Therefore, if the assignee is not set explicitly, we will just not set an assignee at all. The assignee should not be critical to any part of the automation.

See also https://github.com/pulumi/ci-mgmt/pull/1127