### PR TITLE
Fix duplicate PRs in CI

### DIFF
--- a/step/v2/replay.go
+++ b/step/v2/replay.go
@@ -54,6 +54,7 @@ type Replay struct {
 }
 
 func NewReplay(t *testing.T, source []byte) *Replay {
+	t.Helper()
 	var s ReplayV1
 	err := json.Unmarshal(source, &s)
 	require.NoError(t, err)
@@ -64,6 +65,7 @@ func (r *Replay) setPipeline(name string) {
 	if name == "" {
 		return
 	}
+	r.t.Helper()
 	r.t.Logf("Searching for pipeline %q", name)
 	for i := r.pipeline; i < len(r.r.Pipelines); i++ {
 		p := r.r.Pipelines[i]
@@ -87,6 +89,7 @@ func (r *Replay) setPipeline(name string) {
 }
 
 func (r *Replay) findNextStep(name string) int {
+	r.t.Helper()
 	current := r.next
 	for {
 		// We are attempting to find the next step, but there is no next step.
@@ -108,6 +111,7 @@ func (r *Replay) findNextStep(name string) int {
 }
 
 func (r *Replay) Enter(_ context.Context, info StepInfo) error {
+	r.t.Helper()
 	r.setPipeline(info.Pipeline())
 	r.t.Logf("Searching for step: %q (from step %d)", info.Name(), r.next)
 	current := r.findNextStep(info.Name())
@@ -141,6 +145,7 @@ func (r *Replay) Enter(_ context.Context, info StepInfo) error {
 }
 
 func (r *Replay) Exit(_ context.Context, output []any) error {
+	r.t.Helper()
 	if len(r.pending) == 0 {
 		return fmt.Errorf("internal: exit without entry")
 	}
@@ -347,6 +352,7 @@ func getReplay(ctx context.Context) *Replay {
 // It is expected that this function is used only in tests.
 func CallWithReplay(ctx context.Context, pipeline, stepName string, f any) error {
 	r := *getReplay(ctx) // Don't mutate the replay
+	r.t.Helper()
 
 	r.setPipeline(pipeline)
 

--- a/upgrade/steps_test.go
+++ b/upgrade/steps_test.go
@@ -86,19 +86,19 @@ func TestGetWorkingBranch(t *testing.T) {
 func TestHasRemoteBranch(t *testing.T) {
 	t.Parallel()
 	tests := []struct {
-		response   string
-		branchName string
-		expect     bool
+		response string
+		prTitle  string
+		expect   bool
 	}{
 		{
-			response:   `[{"headRefName":"dependabot/go_modules/provider/golang.org/x/net-0.17.0","title":"Bump golang.org/x/net from 0.13.0 to 0.17.0 in /provider"},{"headRefName":"dependabot/go_modules/sdk/golang.org/x/net-0.17.0","title":"bump golang.org/x/net from 0.10.0 to 0.17.0 in /sdk"},{"headRefName":"dependabot/go_modules/examples/golang.org/x/net-0.17.0","title":"Bump golang.org/x/net from 0.8.0 to 0.17.0 in /examples"}]`,
-			branchName: "upgrade-pulumi-terraform-bridge-to-v3.62.0",
-			expect:     false,
+			response: `[{"title":"Bump golang.org/x/net from 0.13.0 to 0.17.0 in /provider"},{"title":"bump golang.org/x/net from 0.10.0 to 0.17.0 in /sdk"},{"title":"Bump golang.org/x/net from 0.8.0 to 0.17.0 in /examples"}]`,
+			prTitle:  "Upgrade pulumi-terraform-bridge to v3.62.0",
+			expect:   false,
 		},
 		{
-			response:   `[{"headRefName":"upgrade-pulumi-terraform-bridge-to-v3.62.0","title":"Upgrade pulumi-terraform-bridge to v3.62.0"},{"headRefName":"dependabot/go_modules/provider/golang.org/x/net-0.17.0","title":"Bump golang.org/x/net from 0.13.0 to 0.17.0 in /provider"},{"headRefName":"dependabot/go_modules/sdk/golang.org/x/net-0.17.0","title":"bump golang.org/x/net from 0.10.0 to 0.17.0 in /sdk"},{"headRefName":"dependabot/go_modules/examples/golang.org/x/net-0.17.0","title":"Bump golang.org/x/net from 0.8.0 to 0.17.0 in /examples"}]`,
-			branchName: "upgrade-pulumi-terraform-bridge-to-v3.62.0",
-			expect:     true,
+			response: `[{"title":"Upgrade pulumi-terraform-bridge to v3.62.0"},{"title":"Bump golang.org/x/net from 0.13.0 to 0.17.0 in /provider"},{"title":"bump golang.org/x/net from 0.10.0 to 0.17.0 in /sdk"},{"title":"Bump golang.org/x/net from 0.8.0 to 0.17.0 in /examples"}]`,
+			prTitle:  "Upgrade pulumi-terraform-bridge to v3.62.0",
+			expect:   true,
 		},
 	}
 
@@ -115,19 +115,19 @@ func TestHasRemoteBranch(t *testing.T) {
 
 			testReplay(context.Background(), t, []*step.Step{
 				{
-					Name:    "Has Remote Branch",
-					Inputs:  encode([]string{tt.branchName}),
+					Name:    "Has Existing PR",
+					Inputs:  encode([]string{tt.prTitle}),
 					Outputs: encode([]any{tt.expect, nil}),
 				},
 				{
 					Name: "gh",
 					Inputs: encode([]any{
-						"gh", []string{"pr", "list", "--json=title,headRefName"},
+						"gh", []string{"pr", "list", "--json=title"},
 					}),
 					Outputs: encode([]any{tt.response, nil}),
 					Impure:  true,
 				},
-			}, "Has Remote Branch", hasRemoteBranch)
+			}, "Has Existing PR", hasExistingPr)
 		})
 	}
 }

--- a/upgrade/upgrade_provider.go
+++ b/upgrade/upgrade_provider.go
@@ -188,10 +188,16 @@ func UpgradeProvider(ctx context.Context, repoOrg, repoName string) (err error) 
 	err = stepv2.PipelineCtx(ctx, "Setup working branch", func(ctx context.Context) {
 		repo.workingBranch = getWorkingBranch(ctx, *GetContext(ctx), targetBridgeVersion, targetPfVersion, upgradeTarget)
 		ensureBranchCheckedOut(ctx, repo.workingBranch)
-		repo.prAlreadyExists = hasRemoteBranch(ctx, repo.workingBranch)
+		repo.prAlreadyExists = hasExistingPr(ctx, repo.prTitle)
 	})
 	if err != nil {
 		return err
+	}
+
+	if prTitle, err := prTitle(ctx, upgradeTarget, targetBridgeVersion, targetPfVersion); err != nil {
+		return err
+	} else {
+		repo.prTitle = prTitle
 	}
 
 	if GetContext(ctx).MajorVersionBump {

--- a/upgrade/upgrade_test.go
+++ b/upgrade/upgrade_test.go
@@ -35,6 +35,7 @@ func TestInformGithub(t *testing.T) {
 				Version: semver.MustParse("5.0.5"),
 			}, ProviderRepo{
 				workingBranch:          "upgrade-terraform-provider-wavefront-to-v5.0.5",
+				prTitle:                "Upgrade terraform-provider-wavefront to v5.0.5",
 				defaultBranch:          "master",
 				Name:                   "pulumi/pulumi-wavefront",
 				currentUpstreamVersion: semver.MustParse("5.0.3"),
@@ -68,6 +69,7 @@ func TestInformGithubExistingPR(t *testing.T) {
 		InformGitHub(ctx,
 			nil, ProviderRepo{
 				workingBranch:   "upgrade-pulumi-terraform-bridge-to-v3.62.0",
+				prTitle:         "Upgrade pulumi-terraform-bridge to v3.62.0",
 				defaultBranch:   "master",
 				Name:            "pulumi/pulumi-kong",
 				prAlreadyExists: true,

--- a/upgrade/upgrade_test.go
+++ b/upgrade/upgrade_test.go
@@ -107,6 +107,7 @@ func TestBridgeUpgradeNoop(t *testing.T) {
 }
 
 func newReplay(t *testing.T, name string) context.Context {
+	t.Helper()
 	ctx := context.Background()
 	path := filepath.Join("testdata", "replay", name+".json")
 	bytes := readFile(t, path)
@@ -115,12 +116,14 @@ func newReplay(t *testing.T, name string) context.Context {
 }
 
 func readFile(t *testing.T, path string) []byte {
+	t.Helper()
 	bytes, err := os.ReadFile(path)
 	require.NoError(t, err)
 	return bytes
 }
 
 func testReplay(ctx context.Context, t *testing.T, stepReplay []*step.Step, fName string, f any) {
+	t.Helper()
 	bytes, err := json.Marshal(step.ReplayV1{
 		Pipelines: []step.RecordV1{{
 			Name:  t.Name(),
@@ -137,6 +140,7 @@ func testReplay(ctx context.Context, t *testing.T, stepReplay []*step.Step, fNam
 }
 
 func jsonMarshal[T any](t *testing.T, content string) T {
+	t.Helper()
 	var dst T
 	err := json.Unmarshal([]byte(content), &dst)
 	require.NoError(t, err)

--- a/upgrade/util.go
+++ b/upgrade/util.go
@@ -131,6 +131,8 @@ type ProviderRepo struct {
 	defaultBranch string
 	// The working branch of the repository
 	workingBranch string
+	// The title of the PR to be created
+	prTitle string
 	// If there is already a PR on GitHub who is merging from `repo.workingBranch`.
 	prAlreadyExists bool
 


### PR DESCRIPTION
Check for PRs based on title rather than branch name as the branch name isn't a stable identifier.

Attempt to make test logging line numbers more accurate, but this really needs reworking to not capture the test context in the struct.