### PR TITLE
Stop filtering on search token when finding applicable issues

### DIFF
--- a/upgrade/steps_helpers.go
+++ b/upgrade/steps_helpers.go
@@ -620,7 +620,6 @@ var getExpectedTargetFromIssues = stepv2.Func11E("From Issues", func(ctx context
 		"--state=open",
 		"--repo="+name,
 		"--limit=100",
-		fmt.Sprintf("--search=%q", upgradeIssueToken),
 		"--json=title,number")
 	titles := []struct {
 		Title  string `json:"title"`

--- a/upgrade/steps_helpers_test.go
+++ b/upgrade/steps_helpers_test.go
@@ -275,7 +275,6 @@ func TestGetExpectedTargetFromTarget(t *testing.T) {
         "--state=open",
         "--repo=pulumi/pulumi-cloudflare",
         "--limit=100",
-        "--search=\"pulumiupgradeproviderissue\"",
         "--json=title,number"
       ]
     ],


### PR DESCRIPTION
This might be running very quickly after the issue was created and it might not yet be indexed. Instead, just list the latest 100 issues and filter on exact title format instead.

The current rate of issue creation is low enough that the latest 100 issues should safely include all open upgrade issues.

Fixes https://github.com/pulumi/upgrade-provider/issues/291

We'll continue to use the token for issue de-duplication as this only happens once per day and so is reliably in the GH issue search index.