### PR TITLE
Fix existing PR detection

### DIFF
--- a/upgrade/steps.go
+++ b/upgrade/steps.go
@@ -7,8 +7,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/fs"
-	"math"
-	"math/rand"
 	"os"
 	"path"
 	"path/filepath"
@@ -495,16 +493,11 @@ var hasExistingPr = stepv2.Func21("Has Existing PR", func(ctx context.Context, p
 var getWorkingBranch = stepv2.Func41E("Working Branch Name", func(ctx context.Context, c Context,
 	targetBridgeVersion, targetPfVersion Ref, upgradeTarget *UpstreamUpgradeTarget,
 ) (string, error) {
-	ciSuffix := stepv2.Func01("Random Suffix", func(ctx context.Context) string {
-		stepv2.MarkImpure(ctx) // This needs to be impure since it is random
-		return fmt.Sprintf("-%08d", rand.Intn(int(math.Pow10(8))))
-	})
-
 	ret := func(format string, a ...any) (string, error) {
 		s := fmt.Sprintf(format, a...)
 
 		if stepv2.GetEnv(ctx, "CI") == "true" {
-			s += ciSuffix(ctx)
+			s += "-ci"
 		}
 
 		stepv2.SetLabel(ctx, s)

--- a/upgrade/steps.go
+++ b/upgrade/steps.go
@@ -473,8 +473,8 @@ var ensureBranchCheckedOut = stepv2.Func10("Ensure Branch", func(ctx context.Con
 	}
 })
 
-var hasExistingPr = stepv2.Func11("Has Existing PR", func(ctx context.Context, prTitle string) bool {
-	prBytes := []byte(stepv2.Cmd(ctx, "gh", "pr", "list", "--json=title"))
+var hasExistingPr = stepv2.Func21("Has Existing PR", func(ctx context.Context, prTitle, repo string) bool {
+	prBytes := []byte(stepv2.Cmd(ctx, "gh", "pr", "list", "--json=title", fmt.Sprintf("--repo=%s", repo)))
 	prs := []struct {
 		Title string `json:"title"`
 	}{}

--- a/upgrade/steps.go
+++ b/upgrade/steps.go
@@ -471,16 +471,17 @@ var ensureBranchCheckedOut = stepv2.Func10("Ensure Branch", func(ctx context.Con
 	}
 })
 
-var hasExistingPr = stepv2.Func21("Has Existing PR", func(ctx context.Context, prTitle, repo string) bool {
-	prBytes := []byte(stepv2.Cmd(ctx, "gh", "pr", "list", "--json=title", fmt.Sprintf("--repo=%s", repo)))
+var hasExistingPr = stepv2.Func21("Has Existing PR", func(ctx context.Context, branchName, repo string) bool {
+	prBytes := []byte(stepv2.Cmd(ctx, "gh", "pr", "list", "--json=title,headRefName", fmt.Sprintf("--repo=%s", repo)))
 	prs := []struct {
-		Title string `json:"title"`
+		Title       string `json:"title"`
+		HeadRefName string `json:"headRefName"`
 	}{}
 	err := json.Unmarshal(prBytes, &prs)
 	stepv2.HaltOnError(ctx, err)
 
 	for _, pr := range prs {
-		if pr.Title == prTitle {
+		if pr.HeadRefName == branchName {
 			stepv2.SetLabel(ctx, fmt.Sprintf("yes %q", pr.Title))
 			return true
 		}

--- a/upgrade/steps_test.go
+++ b/upgrade/steps_test.go
@@ -52,7 +52,7 @@ func TestGetWorkingBranch(t *testing.T) {
 			err := step.Pipeline(t.Name(), func(ctx context.Context) {
 				actual := getWorkingBranch(ctx, tt.c, tt.targetBridgeVersion, tt.targetPfVersion, &tt.upgradeTarget)
 				if os.Getenv("CI") == "true" {
-					assert.Regexp(t, "^"+tt.expected+"-[0-9]{8}$", actual)
+					assert.Regexp(t, "^"+tt.expected+"-ci$", actual)
 				} else {
 					assert.Equal(t, tt.expected, actual)
 				}

--- a/upgrade/steps_test.go
+++ b/upgrade/steps_test.go
@@ -86,19 +86,19 @@ func TestGetWorkingBranch(t *testing.T) {
 func TestHasRemoteBranch(t *testing.T) {
 	t.Parallel()
 	tests := []struct {
-		response string
-		prTitle  string
-		expect   bool
+		response   string
+		branchName string
+		expect     bool
 	}{
 		{
-			response: `[{"title":"Bump golang.org/x/net from 0.13.0 to 0.17.0 in /provider"},{"title":"bump golang.org/x/net from 0.10.0 to 0.17.0 in /sdk"},{"title":"Bump golang.org/x/net from 0.8.0 to 0.17.0 in /examples"}]`,
-			prTitle:  "Upgrade pulumi-terraform-bridge to v3.62.0",
-			expect:   false,
+			response:   `[{"headRefName":"dependabot/go_modules/provider/golang.org/x/net-0.17.0","title":"Bump golang.org/x/net from 0.13.0 to 0.17.0 in /provider"},{"headRefName":"dependabot/go_modules/sdk/golang.org/x/net-0.17.0","title":"bump golang.org/x/net from 0.10.0 to 0.17.0 in /sdk"},{"headRefName":"dependabot/go_modules/examples/golang.org/x/net-0.17.0","title":"Bump golang.org/x/net from 0.8.0 to 0.17.0 in /examples"}]`,
+			branchName: "upgrade-pulumi-terraform-bridge-to-v3.62.0",
+			expect:     false,
 		},
 		{
-			response: `[{"title":"Upgrade pulumi-terraform-bridge to v3.62.0"},{"title":"Bump golang.org/x/net from 0.13.0 to 0.17.0 in /provider"},{"title":"bump golang.org/x/net from 0.10.0 to 0.17.0 in /sdk"},{"title":"Bump golang.org/x/net from 0.8.0 to 0.17.0 in /examples"}]`,
-			prTitle:  "Upgrade pulumi-terraform-bridge to v3.62.0",
-			expect:   true,
+			response:   `[{"headRefName":"upgrade-pulumi-terraform-bridge-to-v3.62.0","title":"Upgrade pulumi-terraform-bridge to v3.62.0"},{"headRefName":"dependabot/go_modules/provider/golang.org/x/net-0.17.0","title":"Bump golang.org/x/net from 0.13.0 to 0.17.0 in /provider"},{"headRefName":"dependabot/go_modules/sdk/golang.org/x/net-0.17.0","title":"bump golang.org/x/net from 0.10.0 to 0.17.0 in /sdk"},{"headRefName":"dependabot/go_modules/examples/golang.org/x/net-0.17.0","title":"Bump golang.org/x/net from 0.8.0 to 0.17.0 in /examples"}]`,
+			branchName: "upgrade-pulumi-terraform-bridge-to-v3.62.0",
+			expect:     true,
 		},
 	}
 
@@ -116,13 +116,13 @@ func TestHasRemoteBranch(t *testing.T) {
 			testReplay(context.Background(), t, []*step.Step{
 				{
 					Name:    "Has Existing PR",
-					Inputs:  encode([]string{tt.prTitle, "pulumi/pulumi-xyz"}),
+					Inputs:  encode([]string{tt.branchName, "pulumi/pulumi-xyz"}),
 					Outputs: encode([]any{tt.expect, nil}),
 				},
 				{
 					Name: "gh",
 					Inputs: encode([]any{
-						"gh", []string{"pr", "list", "--json=title", "--repo=pulumi/pulumi-xyz"},
+						"gh", []string{"pr", "list", "--json=title,headRefName", "--repo=pulumi/pulumi-xyz"},
 					}),
 					Outputs: encode([]any{tt.response, nil}),
 					Impure:  true,

--- a/upgrade/steps_test.go
+++ b/upgrade/steps_test.go
@@ -116,13 +116,13 @@ func TestHasRemoteBranch(t *testing.T) {
 			testReplay(context.Background(), t, []*step.Step{
 				{
 					Name:    "Has Existing PR",
-					Inputs:  encode([]string{tt.prTitle}),
+					Inputs:  encode([]string{tt.prTitle, "pulumi/pulumi-xyz"}),
 					Outputs: encode([]any{tt.expect, nil}),
 				},
 				{
 					Name: "gh",
 					Inputs: encode([]any{
-						"gh", []string{"pr", "list", "--json=title"},
+						"gh", []string{"pr", "list", "--json=title", "--repo=pulumi/pulumi-xyz"},
 					}),
 					Outputs: encode([]any{tt.response, nil}),
 					Impure:  true,

--- a/upgrade/upgrade_provider.go
+++ b/upgrade/upgrade_provider.go
@@ -184,6 +184,12 @@ func UpgradeProvider(ctx context.Context, repoOrg, repoName string) (err error) 
 		}
 	}
 
+	if prTitle, err := prTitle(ctx, upgradeTarget, targetBridgeVersion, targetPfVersion); err != nil {
+		return err
+	} else {
+		repo.prTitle = prTitle
+	}
+
 	var targetSHA string
 	err = stepv2.PipelineCtx(ctx, "Setup working branch", func(ctx context.Context) {
 		repo.workingBranch = getWorkingBranch(ctx, *GetContext(ctx), targetBridgeVersion, targetPfVersion, upgradeTarget)
@@ -192,12 +198,6 @@ func UpgradeProvider(ctx context.Context, repoOrg, repoName string) (err error) 
 	})
 	if err != nil {
 		return err
-	}
-
-	if prTitle, err := prTitle(ctx, upgradeTarget, targetBridgeVersion, targetPfVersion); err != nil {
-		return err
-	} else {
-		repo.prTitle = prTitle
 	}
 
 	if GetContext(ctx).MajorVersionBump {

--- a/upgrade/upgrade_provider.go
+++ b/upgrade/upgrade_provider.go
@@ -194,7 +194,7 @@ func UpgradeProvider(ctx context.Context, repoOrg, repoName string) (err error) 
 	err = stepv2.PipelineCtx(ctx, "Setup working branch", func(ctx context.Context) {
 		repo.workingBranch = getWorkingBranch(ctx, *GetContext(ctx), targetBridgeVersion, targetPfVersion, upgradeTarget)
 		ensureBranchCheckedOut(ctx, repo.workingBranch)
-		repo.prAlreadyExists = hasExistingPr(ctx, repo.prTitle, repo.Org+"/"+repo.Name)
+		repo.prAlreadyExists = hasExistingPr(ctx, repo.workingBranch, repo.Org+"/"+repo.Name)
 	})
 	if err != nil {
 		return err

--- a/upgrade/upgrade_provider.go
+++ b/upgrade/upgrade_provider.go
@@ -188,7 +188,7 @@ func UpgradeProvider(ctx context.Context, repoOrg, repoName string) (err error) 
 	err = stepv2.PipelineCtx(ctx, "Setup working branch", func(ctx context.Context) {
 		repo.workingBranch = getWorkingBranch(ctx, *GetContext(ctx), targetBridgeVersion, targetPfVersion, upgradeTarget)
 		ensureBranchCheckedOut(ctx, repo.workingBranch)
-		repo.prAlreadyExists = hasExistingPr(ctx, repo.prTitle)
+		repo.prAlreadyExists = hasExistingPr(ctx, repo.prTitle, repo.Org+"/"+repo.Name)
 	})
 	if err != nil {
 		return err


### PR DESCRIPTION
Fixes #297 

## Attempt 1

Set PR title before accessing it 
- We were using the `repo.prTitle` before it was assigned a value which meant it was always an empty string while checking for existing PRs and therefore it never found an existing PR.

Set repo explicitly when querying PRs 
- Rule out possibility that the CLI is looking in the wrong repo.

[First test run failed](https://github.com/pulumi/pulumi-pagerduty/actions/runs/11799391121/job/32867773802) because the branch name in CI was always randomized so made the branch name consistent.

## Attempt 2

[Second test run failed](https://github.com/pulumi/pulumi-pagerduty/actions/runs/11799583593/job/32868434462) because although a PR with the same name already exists, attempting to update it based on branch name fails because the branch might have come from somewhere else. Therefore we should move out duplicate check back to using branch name now that branch name is a predictable identifier. See also #290 

## Attempt 3

Use sane, predictable branch names in CI and revert back to identifying existing PRs by branch name 
- This avoids CI trying to modify user-created PRs. This is more reliable because we're using the same identifier when checking for existence as when we're attempting the update.

1. [First test run](https://github.com/pulumi/pulumi-pagerduty/actions/runs/11799797913) creates a [new PR](https://github.com/pulumi/pulumi-pagerduty/pull/667) as the new stable branch name doesn't yet exist.
2. [Second test run](https://github.com/pulumi/pulumi-pagerduty/actions/runs/11799938725/job/32869663923) updates the existing PR