### PR TITLE
Fix upstream.sh path

### DIFF
--- a/upgrade/steps.go
+++ b/upgrade/steps.go
@@ -163,11 +163,11 @@ func UpgradeProviderVersion(
 			// We need to remove any patches to so we can cleanly pull the next upstream version.
 			step.Cmd("git", "reset", "HEAD", "--hard").In(&upstreamDir),
 			// Load patches into a branch.
-			step.Cmd("./upstream.sh", "checkout").In(&repo.root),
+			step.Cmd("./scripts/upstream.sh", "checkout").In(&repo.root),
 			// Rebase the upstream tracking branch onto the new version.
-			step.Cmd("./upstream.sh", "rebase", "-o", "refs/tags/v"+target.String()).In(&repo.root),
+			step.Cmd("./scripts/upstream.sh", "rebase", "-o", "refs/tags/v"+target.String()).In(&repo.root),
 			// Turn the rebased commits back into patches.
-			step.Cmd("./upstream.sh", "check_in").In(&repo.root),
+			step.Cmd("./scripts/upstream.sh", "check_in").In(&repo.root),
 		))
 	}
 


### PR DESCRIPTION
In https://github.com/pulumi/ci-mgmt/pull/1362 we're moving the location of the upstream.sh into the scripts directory to keep the root of the repo cleaner. This update keeps this tool in line with the new location.