### PR TITLE
add PR prefix to branch name

### DIFF
--- a/upgrade/steps.go
+++ b/upgrade/steps.go
@@ -493,13 +493,15 @@ var hasExistingPr = stepv2.Func21("Has Existing PR", func(ctx context.Context, b
 
 var getWorkingBranch = stepv2.Func51E("Working Branch Name", func(ctx context.Context, c Context,
 	targetBridgeVersion, targetPfVersion Ref, upgradeTarget *UpstreamUpgradeTarget,
-	branchSuffix string,
+	prTitlePrefix string,
 ) (string, error) {
 	ret := func(format string, a ...any) (string, error) {
 		s := fmt.Sprintf(format, a...)
 
-		if branchSuffix != "" {
-			s += "-" + branchSuffix
+		if prTitlePrefix != "" {
+			prTitlePrefix = strings.ToLower(prTitlePrefix)
+			prTitlePrefix = regexp.MustCompile(`[^a-zA-Z0-9]`).ReplaceAllString(prTitlePrefix, "")
+			s += "-" + prTitlePrefix
 		}
 
 		if stepv2.GetEnv(ctx, "CI") == "true" {

--- a/upgrade/steps.go
+++ b/upgrade/steps.go
@@ -491,11 +491,16 @@ var hasExistingPr = stepv2.Func21("Has Existing PR", func(ctx context.Context, b
 	return false
 })
 
-var getWorkingBranch = stepv2.Func41E("Working Branch Name", func(ctx context.Context, c Context,
+var getWorkingBranch = stepv2.Func51E("Working Branch Name", func(ctx context.Context, c Context,
 	targetBridgeVersion, targetPfVersion Ref, upgradeTarget *UpstreamUpgradeTarget,
+	branchSuffix string,
 ) (string, error) {
 	ret := func(format string, a ...any) (string, error) {
 		s := fmt.Sprintf(format, a...)
+
+		if branchSuffix != "" {
+			s += "-" + branchSuffix
+		}
 
 		if stepv2.GetEnv(ctx, "CI") == "true" {
 			s += "-ci"

--- a/upgrade/steps_test.go
+++ b/upgrade/steps_test.go
@@ -55,6 +55,16 @@ func TestGetWorkingBranch(t *testing.T) {
 			branchSuffix:        "foo",
 			expected:            "upgrade-pulumi-terraform-bridge-to-1.2.3-foo",
 		},
+		{
+			c: Context{
+				UpgradeBridgeVersion: true,
+				TargetBridgeRef:      &Version{SemVer: semver.MustParse("v1.2.3")},
+				PRTitlePrefix:        "[DOWNSTREAM TEST] [PLATFORM]",
+			},
+			targetBridgeVersion: &Version{SemVer: semver.MustParse("1.2.3")},
+			branchSuffix:        "[DOWNSTREAM TEST] [PLATFORM]",
+			expected:            "upgrade-pulumi-terraform-bridge-to-1.2.3-downstreamtestplatform",
+		},
 		{expectedErr: "unknown action"}, // If no action can be produced, we should error.
 	}
 

--- a/upgrade/steps_test.go
+++ b/upgrade/steps_test.go
@@ -21,6 +21,7 @@ func TestGetWorkingBranch(t *testing.T) {
 		c                                    Context
 		targetBridgeVersion, targetPfVersion Ref
 		upgradeTarget                        UpstreamUpgradeTarget
+		branchSuffix                         string
 
 		expected    string
 		expectedErr string
@@ -31,6 +32,7 @@ func TestGetWorkingBranch(t *testing.T) {
 				UpgradeProviderVersion: true,
 				UpstreamProviderName:   "foo",
 			},
+			branchSuffix:  "",
 			upgradeTarget: UpstreamUpgradeTarget{Version: semver.MustParse("1.2.3")},
 			expected:      "upgrade-foo-to-v1.2.3",
 		},
@@ -39,8 +41,19 @@ func TestGetWorkingBranch(t *testing.T) {
 				UpgradeBridgeVersion: true,
 				TargetBridgeRef:      &Version{SemVer: semver.MustParse("v1.2.3")},
 			},
+			branchSuffix:        "",
 			targetBridgeVersion: &Version{SemVer: semver.MustParse("1.2.3")},
 			expected:            "upgrade-pulumi-terraform-bridge-to-1.2.3",
+		},
+		{
+			c: Context{
+				UpgradeBridgeVersion: true,
+				TargetBridgeRef:      &Version{SemVer: semver.MustParse("v1.2.3")},
+				PRTitlePrefix:        "foo",
+			},
+			targetBridgeVersion: &Version{SemVer: semver.MustParse("1.2.3")},
+			branchSuffix:        "foo",
+			expected:            "upgrade-pulumi-terraform-bridge-to-1.2.3-foo",
 		},
 		{expectedErr: "unknown action"}, // If no action can be produced, we should error.
 	}
@@ -50,7 +63,7 @@ func TestGetWorkingBranch(t *testing.T) {
 			t.Parallel()
 
 			err := step.Pipeline(t.Name(), func(ctx context.Context) {
-				actual := getWorkingBranch(ctx, tt.c, tt.targetBridgeVersion, tt.targetPfVersion, &tt.upgradeTarget)
+				actual := getWorkingBranch(ctx, tt.c, tt.targetBridgeVersion, tt.targetPfVersion, &tt.upgradeTarget, tt.branchSuffix)
 				if os.Getenv("CI") == "true" {
 					assert.Regexp(t, "^"+tt.expected+"-ci$", actual)
 				} else {

--- a/upgrade/upgrade_provider.go
+++ b/upgrade/upgrade_provider.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"regexp"
 	"sort"
 	"strings"
 
@@ -190,9 +191,15 @@ func UpgradeProvider(ctx context.Context, repoOrg, repoName string) (err error) 
 		repo.prTitle = prTitle
 	}
 
+	branchSuffix := GetContext(ctx).PRTitlePrefix
+	if branchSuffix != "" {
+		branchSuffix = strings.ToLower(branchSuffix)
+		branchSuffix = regexp.MustCompile(`[^a-zA-Z0-9]`).ReplaceAllString(branchSuffix, "")
+	}
+
 	var targetSHA string
 	err = stepv2.PipelineCtx(ctx, "Setup working branch", func(ctx context.Context) {
-		repo.workingBranch = getWorkingBranch(ctx, *GetContext(ctx), targetBridgeVersion, targetPfVersion, upgradeTarget)
+		repo.workingBranch = getWorkingBranch(ctx, *GetContext(ctx), targetBridgeVersion, targetPfVersion, upgradeTarget, branchSuffix)
 		ensureBranchCheckedOut(ctx, repo.workingBranch)
 		repo.prAlreadyExists = hasExistingPr(ctx, repo.workingBranch, repo.Org+"/"+repo.Name)
 	})

--- a/upgrade/upgrade_provider.go
+++ b/upgrade/upgrade_provider.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"regexp"
 	"sort"
 	"strings"
 
@@ -191,15 +190,11 @@ func UpgradeProvider(ctx context.Context, repoOrg, repoName string) (err error) 
 		repo.prTitle = prTitle
 	}
 
-	branchSuffix := GetContext(ctx).PRTitlePrefix
-	if branchSuffix != "" {
-		branchSuffix = strings.ToLower(branchSuffix)
-		branchSuffix = regexp.MustCompile(`[^a-zA-Z0-9]`).ReplaceAllString(branchSuffix, "")
-	}
+	prTitlePrefix := GetContext(ctx).PRTitlePrefix
 
 	var targetSHA string
 	err = stepv2.PipelineCtx(ctx, "Setup working branch", func(ctx context.Context) {
-		repo.workingBranch = getWorkingBranch(ctx, *GetContext(ctx), targetBridgeVersion, targetPfVersion, upgradeTarget, branchSuffix)
+		repo.workingBranch = getWorkingBranch(ctx, *GetContext(ctx), targetBridgeVersion, targetPfVersion, upgradeTarget, prTitlePrefix)
 		ensureBranchCheckedOut(ctx, repo.workingBranch)
 		repo.prAlreadyExists = hasExistingPr(ctx, repo.workingBranch, repo.Org+"/"+repo.Name)
 	})


### PR DESCRIPTION
This PR adds the PR prefix to the branch name when running upgrade-provider. This should avoid the confusing and dangerous situation where legitimate upgrade branches are clobbered by test runs of upgrade-provider.

fixes https://github.com/pulumi/upgrade-provider/issues/305