### PR TITLE
Add patch release option

### DIFF
--- a/main.go
+++ b/main.go
@@ -256,6 +256,9 @@ This is equivalent to setting PULUMI_MISSING_DOCS_ERROR=${! VALUE}.`)
 	cmd.PersistentFlags().StringVar(&context.PRTitlePrefix, "pr-title-prefix", "",
 		`The prefix to insert in the generated pull request title.`)
 
+	cmd.PersistentFlags().BoolVar(&context.PatchRelease, "patch-release", false,
+		`Create a patch release for the provider.`)
+
 	return cmd
 }
 

--- a/upgrade/steps.go
+++ b/upgrade/steps.go
@@ -341,6 +341,8 @@ var InformGitHub = stepv2.Func70E("Inform Github", func(
 		// if the provider hasn't been released in 8 weeks.
 		case c.MaintenancePatch && !c.UpgradeProviderVersion:
 			extraOptions = []string{"--label", "needs-release/patch"}
+		case c.PatchRelease:
+			extraOptions = []string{"--label", "needs-release/patch"}
 		}
 
 		stepv2.Cmd(ctx, "gh",
@@ -597,6 +599,7 @@ var majorVersionBump = stepv2.Func30("Increment Major Version", func(
 
 	nextMajorVersion := stepv2.NamedValue(ctx, "Next major version",
 		repo.currentVersion.IncMajor().String())
+
 
 	stepv2.WithCwd(ctx, repo.root, func(ctx context.Context) {
 		updateFile(ctx, "Update PROVIDER_PATH", ".ci-mgmt.yaml",

--- a/upgrade/util.go
+++ b/upgrade/util.go
@@ -93,6 +93,9 @@ type Context struct {
 
 	PRDescription string
 	PRTitlePrefix string
+
+	// If true, create a patch release for the provider.
+	PatchRelease bool
 }
 
 // Check if the user specified operating in the current working directory (CWD) with `--repo-path=.`. In this case the


### PR DESCRIPTION
This PR adds a --patch-release option which adds the `needs-release/patch` label to the PR generated by `upgrade-provider`.

Example: https://github.com/pulumi/pulumi-random/pull/1791

Part of https://github.com/pulumi/pulumi-terraform-bridge/issues/2267