### PR TITLE
Generate, do not build the SDKs

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,10 +77,10 @@ Flags:
       --repo-path string                Clone the provider repo to the specified path.
       --target-bridge-version ref       The desired bridge version to upgrade to. Git hash references permitted. (default <latest>)
       --target-pulumi-version ref       Upgrade the provider to the passed pulumi/{pkg,sdk} version.
-                                        
+
                                         If no version is passed, the pulumi/{pkg,sdk} version will track the bridge
       --target-version string           Upgrade the provider to the passed version.
-                                        
+
                                         If the passed version does not exist, an error is signaled.
       --upstream-provider-name string   The name of the upstream provider.
                                         Required unless running from provider root and set in upgrade-config.yml.
@@ -117,9 +117,9 @@ A typical run for a patched provider with an upgrade configuration file will loo
 - ✓ /usr/bin/make tfgen: done
 - ✓ /usr/local/bin/git add --all: done
 - ✓ /usr/local/bin/git commit -m make tfgen: done
-- ✓ /usr/bin/make build_sdks: done
+- ✓ /usr/bin/make generate_sdks: done
 - ✓ /usr/local/bin/git add --all: done
-- ✓ /usr/local/bin/git commit -m make build_sdks: done
+- ✓ /usr/local/bin/git commit -m make generate_sdks: done
 - Open PR
   - ✓ /usr/local/bin/git push --set-upstream origin upgrade-terraform-provider-snowfla...: done
   - ✓ /usr/local/bin/gh pr create --assignee @me --base master --head upgrade-terrafor...: done
@@ -176,9 +176,9 @@ ok = step.Run(step.Combined("Upgrading Provider",
 			step.Cmd(exec.CommandContext(ctx, "make", "tfgen")).In(&path),
 			step.Cmd(exec.CommandContext(ctx, "git", "add", "--all")).In(&path),
 			step.Cmd(exec.CommandContext(ctx, "git", "commit", "-m", "make tfgen")).In(&path),
-			step.Cmd(exec.CommandContext(ctx, "make", "build_sdks")).In(&path),
+			step.Cmd(exec.CommandContext(ctx, "make", "generate_sdks")).In(&path),
 			step.Cmd(exec.CommandContext(ctx, "git", "add", "--all")).In(&path),
-			step.Cmd(exec.CommandContext(ctx, "git", "commit", "-m", "make build_sdks")).In(&path),
+			step.Cmd(exec.CommandContext(ctx, "git", "commit", "-m", "make generate_sdks")).In(&path),
 			step.Cmd(exec.CommandContext(ctx, "git", "push", "--set-upstream", "origin", branchName)).In(&path),
 		)...))
 ```
@@ -206,7 +206,7 @@ Then the basic provider upgrade is performed:
 2. Upgrade the upstream dependency. (If forked, update the fork)
 3. Upgrade terraform bridge.
 4. Run `make tfgen` and check in the result.
-5. Run `make build_sdks` and check in the result.
+5. Run `make generate_sdks` and check in the result.
 
 If `shim` is a subfolder of `provider`, then upgrades will be performed in `shim`.
 

--- a/step/v2/step.go
+++ b/step/v2/step.go
@@ -142,7 +142,7 @@ func SetLabelf(ctx context.Context, format string, a ...any) {
 }
 
 // Run a function against arguments and set outputs.
-func run(ctx context.Context, name string, f any, inputs, outputs []any) {
+func run(ctx context.Context, name string, f1 any, inputs, outputs []any) {
 	p := mustGetPipeline(ctx, name)
 	done := make(chan struct{})
 

--- a/upgrade/upgrade_provider.go
+++ b/upgrade/upgrade_provider.go
@@ -368,7 +368,7 @@ func tfgenAndBuildSDKs(
 		stepv2.Cmd(ctx, "git", "add", "--all")
 		gitCommit(ctx, "make tfgen")
 
-		stepv2.Cmd(ctx, "make", "build_sdks")
+		stepv2.Cmd(ctx, "make", "generate_sdks")
 
 		// Update sdk/go.mod's module after rebuilding the go SDK
 		if GetContext(ctx).MajorVersionBump {
@@ -390,7 +390,7 @@ func tfgenAndBuildSDKs(
 
 		stepv2.Cmd(ctx, "git", "add", "--all")
 
-		gitCommit(ctx, "make build_sdks")
+		gitCommit(ctx, "make generate_sdks")
 
 		InformGitHub(ctx, upgradeTarget, repo, goMod, targetBridgeVersion,
 			targetPfVersion, tfSDKUpgrade, os.Args)


### PR DESCRIPTION
The change swaps out `make build_sdk` with `make generate_sdk` which is lighter weight and is less prone to failure. 

In particular if upgrade succeeded partially but possibly the .NET SDK does not build would rather have that failing PR stood up than fail and abort having a PR out.

Also it is lighter on resources and imposes fewer constraints on the environment it executes in.

Problem sparking this: https://github.com/pulumi/pulumi-alicloud/issues/990

