### PR TITLE
Ignore errors from make

### DIFF
--- a/upgrade/upgrade_provider.go
+++ b/upgrade/upgrade_provider.go
@@ -363,12 +363,12 @@ func tfgenAndBuildSDKs(
 			stepv2.WriteFile(ctx, ".pulumi-java-gen.version", GetContext(ctx).JavaVersion)
 		}
 
-		stepv2.Cmd(ctx, "make", "tfgen")
+		stepv2.CmdIgnoreError(ctx, "make", "tfgen")
 
-		stepv2.Cmd(ctx, "git", "add", "--all")
+		stepv2.CmdIgnoreError(ctx, "git", "add", "--all")
 		gitCommit(ctx, "make tfgen")
 
-		stepv2.Cmd(ctx, "make", "generate_sdks")
+		stepv2.CmdIgnoreError(ctx, "make", "generate_sdks")
 
 		// Update sdk/go.mod's module after rebuilding the go SDK
 		if GetContext(ctx).MajorVersionBump {


### PR DESCRIPTION
Following up on https://github.com/pulumi/upgrade-provider/pull/312

At Pulumi when using with GitHub actions we almost certainly would prefer the tool to check in a WIP in-progress PR that failed rather than fail and check in no PR. Perhaps some of the actions it took are valid just require manual intervention to post-fix-up.

Ideally the control flow would be: 

```
try:
  make tfgen
  make generate_sdks   
finally:
  create-pr
```

However I do not think the workflow monad here permits a try-finally construct that I could implement quickly. 

As an alternative we can ignore errors from `make tfgen` and `make generate_sdks`.

As another alternative we can make ignoring these errors a flag. Admittedly it is a very strange default behavior. 