### PR TITLE
Replace terraform-plugin-sdk in examples/go.mod when it exists

### DIFF
--- a/upgrade/upgrade_provider.go
+++ b/upgrade/upgrade_provider.go
@@ -234,7 +234,7 @@ func UpgradeProvider(ctx context.Context, repoOrg, repoName string) (err error) 
 		}
 
 		steps = append(steps,
-			setTFPluginSDKReplace(ctx, repo, &tfSDKTargetSHA),
+			setTFPluginSDKReplace(ctx, repo, tfSDKTargetSHA),
 			step.Cmd("go", "mod", "tidy").In(repo.providerDir()))
 
 		return step.Combined("Update Plugin SDK", steps...)


### PR DESCRIPTION
Resolves #246 as the replace is needed in `examples/go.mod` as well if it the provider happens to have it. 