### PR TITLE
Remove logic for current directory - it should always be the provider repo

### DIFF
--- a/main.go
+++ b/main.go
@@ -38,7 +38,6 @@ func cmd() *cobra.Command {
 	var upgradeKind []string
 	var repoName string
 	var repoOrg string
-	var repoPath string
 
 	ctx := context.Background()
 	context := upgrade.Context{GoPath: gopath}
@@ -141,8 +140,6 @@ func cmd() *cobra.Command {
 						upgradeKind)
 				}
 			}
-			// Set repoPath if specified
-			context.SetRepoPath(repoPath)
 
 			if context.TargetVersion != nil && !context.UpgradeProviderVersion {
 				return fmt.Errorf(
@@ -163,9 +160,6 @@ func cmd() *cobra.Command {
 		`Upgrade to the latest Java version`)
 	err := cmd.PersistentFlags().MarkHidden("upgrade-java")
 	contract.AssertNoErrorf(err, "could not mark `upgrade-java` flag as hidden")
-
-	cmd.PersistentFlags().StringVar(&repoPath, "repo-path", "",
-		`Clone the provider repo to the specified path. Skip cloning if set to "."`)
 
 	cmd.PersistentFlags().StringVar(&targetVersion, "target-version", "",
 		`Upgrade the provider to the passed version.

--- a/upgrade/steps.go
+++ b/upgrade/steps.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"io/fs"
 	"os"
-	"path"
 	"path/filepath"
 	"reflect"
 	"regexp"
@@ -40,46 +39,19 @@ var gitCommit = stepv2.Func10("git commit", func(ctx context.Context, msg string
 	}
 })
 
-// Ensure that the upstream repo exists.
-//
-// The path that the upstream repo exists at is returned.
-var ensureUpstreamRepo = stepv2.Func11("Ensure Upstream Repo", func(ctx context.Context, repoPath string) string {
-	expectedLocation := stepv2.Func11E("Expected Location",
-		func(ctx context.Context, repoPath string) (string, error) {
-			cwd := stepv2.GetCwd(ctx)
-			loc, err := getRepoExpectedLocation(ctx, cwd, repoPath)
-			if err != nil {
-				return "", err
-			}
-			stepv2.SetLabel(ctx, loc)
-			return loc, nil
-		})(ctx, repoPath)
+var ensureRepoInCWD = stepv2.Func11E("Ensure Repo in CWD", func(ctx context.Context, repoName string) (string, error) {
+	cwd := stepv2.GetCwd(ctx)
 
-	repoExists := stepv2.Func11E("Repo Exists", func(ctx context.Context, loc string) (bool, error) {
-		info, exists := stepv2.Stat(ctx, loc)
-		if !exists {
-			return false, nil
-		}
-		if !info.IsDir {
-			return false, fmt.Errorf("'%s' not a directory", loc)
-		}
-		return true, nil
-	})(ctx, expectedLocation)
-
-	if !repoExists {
-		stepv2.Func10("Downloading", func(ctx context.Context, path string) {
-			targetDir := stepv2.NamedValue(ctx, "Target Dir", filepath.Dir(path))
-			stepv2.MkDirAll(ctx, targetDir, 0o700)
-			stepv2.Cmd(ctx, "git", "clone", fmt.Sprintf("https://%s.git", repoPath), path)
-		})(ctx, expectedLocation)
+	if filepath.Base(cwd) != repoName {
+		return "", fmt.Errorf("expected repo name '%s' in current directory, got '%s'", repoName, cwd)
 	}
 
 	stepv2.Func10("Validate Repository", func(ctx context.Context, path string) {
-		ctx = stepv2.WithEnv(ctx, &stepv2.SetCwd{To: expectedLocation})
+		ctx = stepv2.WithEnv(ctx, &stepv2.SetCwd{To: cwd})
 		stepv2.Cmd(ctx, "git", "status", "--short")
-	})(ctx, expectedLocation)
+	})(ctx, cwd)
 
-	return expectedLocation
+	return cwd, nil
 })
 
 func UpgradeProviderVersion(
@@ -472,10 +444,6 @@ var getWorkingBranch = stepv2.Func41E("Working Branch Name", func(ctx context.Co
 		return "", fmt.Errorf("calculating branch name: unknown action")
 	}
 })
-
-func OrgProviderRepos(ctx context.Context, org, repo string) string {
-	return ensureUpstreamRepo(ctx, path.Join("github.com", org, repo))
-}
 
 var findDefaultBranch = stepv2.Func11E("Find default Branch", func(ctx context.Context, remote string) (string, error) {
 	lsRemoteHeads := stepv2.Cmd(ctx, "git", "ls-remote", "--heads", remote)

--- a/upgrade/steps.go
+++ b/upgrade/steps.go
@@ -472,16 +472,6 @@ var findDefaultBranch = stepv2.Func11E("Find default Branch", func(ctx context.C
 	return "", fmt.Errorf("could not find 'master' or 'main' branch")
 })
 
-var pullDefaultBranch = stepv2.Func11("Pull Default Branch", func(ctx context.Context, remote string) string {
-	defaultBranch := findDefaultBranch(ctx, remote)
-
-	stepv2.Cmd(ctx, "git", "fetch")
-	stepv2.Cmd(ctx, "git", "checkout", defaultBranch)
-	stepv2.Cmd(ctx, "git", "pull", remote)
-
-	return defaultBranch
-})
-
 var majorVersionBump = stepv2.Func30("Increment Major Version", func(
 	ctx context.Context, goMod *GoMod, target *UpstreamUpgradeTarget, repo ProviderRepo,
 ) {

--- a/upgrade/steps_helpers.go
+++ b/upgrade/steps_helpers.go
@@ -231,11 +231,6 @@ var setCurrentUpstreamFromPatched = stepv2.Func10E("Set Upstream From Patched", 
 		return fmt.Errorf("found empty SHA")
 	}
 
-	// If the user set --repo-path as CWD, do not init the submodules as this is assumed to have been done.
-	if !GetContext(ctx).IsCWD() {
-		stepv2.Cmd(ctx, "git", "submodule", "init")
-	}
-
 	remoteURL := strings.TrimSpace(stepv2.Cmd(ctx,
 		"git", "config", "--get", "submodule.upstream.url"))
 

--- a/upgrade/steps_helpers.go
+++ b/upgrade/steps_helpers.go
@@ -452,35 +452,6 @@ var latestReleaseVersion = stepv2.Func12E("Latest Release Version",
 		return v, true, err
 	})
 
-// getRepoExpectedLocation will return one of the following:
-// 1) --repo-path: if set, returns the specified repo path
-// 2) current working directory: returns the path to the cwd if it is a provider directory
-// or subdirectory, i.e. `user/home/pulumi/pulumi-docker/provider` it
-// 3) default: $GOPATH/src/module, i.e. $GOPATH/src/github.com/pulumi/pulumi-datadog
-func getRepoExpectedLocation(ctx context.Context, cwd, repoPath string) (string, error) {
-	// We assume the user passed in a valid path, either absolute or relative.
-	if path := GetContext(ctx).repoPath; path != "" {
-		return path, nil
-	}
-
-	// Strip version
-	repoPath = modPathWithoutVersion(repoPath)
-
-	// from github.com/org/repo to $GOPATH/src/github.com/org
-	expectedLocation := filepath.Join(strings.Split(repoPath, "/")...)
-
-	expectedBase := filepath.Base(expectedLocation)
-
-	for cwd != "" && cwd != string(os.PathSeparator) && cwd != "." {
-		if filepath.Base(cwd) == expectedBase {
-			return cwd, nil
-		}
-		cwd = filepath.Dir(cwd)
-	}
-
-	return filepath.Join(GetContext(ctx).GoPath, "src", expectedLocation), nil
-}
-
 // Fetch the expected upgrade target from github. Return a list of open upgrade issues,
 // sorted by semantic version. The list may be empty.
 //

--- a/upgrade/steps_helpers_test.go
+++ b/upgrade/steps_helpers_test.go
@@ -2,9 +2,7 @@ package upgrade
 
 import (
 	"context"
-	"fmt"
 	"os"
-	"path/filepath"
 	"strings"
 	"testing"
 
@@ -42,36 +40,6 @@ func TestRemoveVersionPrefix(t *testing.T) {
 		t.Run(tt.input, func(t *testing.T) {
 			actual := modPathWithoutVersion(tt.input)
 			assert.Equal(t, tt.expected, actual)
-		})
-	}
-}
-
-func TestGetRepoExpectedLocation(t *testing.T) {
-	ctx := &Context{
-		GoPath: "/Users/myuser/go",
-	}
-
-	mockRepoPath := filepath.Join("github.com", "pulumi", "random-provider")
-	defaultExpectedLocation := filepath.Join(ctx.GoPath, "src", mockRepoPath)
-
-	baseProviderCwd := string(os.PathSeparator) + filepath.Join("Users", "home", mockRepoPath)
-	subProviderCwd := filepath.Join(baseProviderCwd, "examples")
-	randomCwd := string(os.PathSeparator) + filepath.Join("Users", "random", "dir")
-
-	// test cwd == repo path
-	tests := []struct{ cwd, repoPath, expected string }{
-		{baseProviderCwd, mockRepoPath, baseProviderCwd},   // expected set to cwd
-		{subProviderCwd, mockRepoPath, baseProviderCwd},    // expected set to top level of cwd repo path
-		{randomCwd, mockRepoPath, defaultExpectedLocation}, // expected set to default on no match
-	}
-
-	for _, tt := range tests {
-		tt := tt
-		t.Run(fmt.Sprintf("(%s,%s,%s)", tt.cwd, tt.repoPath, tt.expected), func(t *testing.T) {
-			expected, err := getRepoExpectedLocation(ctx.Wrap(context.Background()), tt.cwd, tt.repoPath)
-			expected = trimSeparators(expected)
-			assert.Nil(t, err)
-			assert.Equal(t, trimSeparators(tt.expected), expected)
 		})
 	}
 }

--- a/upgrade/steps_helpers_test.go
+++ b/upgrade/steps_helpers_test.go
@@ -2,8 +2,6 @@ package upgrade
 
 import (
 	"context"
-	"os"
-	"strings"
 	"testing"
 
 	"github.com/Masterminds/semver/v3"
@@ -42,11 +40,6 @@ func TestRemoveVersionPrefix(t *testing.T) {
 			assert.Equal(t, tt.expected, actual)
 		})
 	}
-}
-
-func trimSeparators(path string) string {
-	return strings.TrimSuffix(strings.TrimPrefix(path, string(os.PathSeparator)),
-		string(os.PathSeparator))
 }
 
 func TestPullRequestBody(t *testing.T) {

--- a/upgrade/steps_test.go
+++ b/upgrade/steps_test.go
@@ -233,13 +233,6 @@ func TestEnsureBranchCheckedOut(t *testing.T) {
 	}
 }
 
-func TestEnsureUpstreamRepo(t *testing.T) {
-	ctx := newReplay(t, "download_aiven")
-	err := step.CallWithReplay((&Context{GoPath: "/goPath"}).Wrap(ctx), "Discover Provider",
-		"Ensure Upstream Repo", ensureUpstreamRepo)
-	require.NoError(t, err)
-}
-
 func TestReleaseLabel(t *testing.T) {
 	t.Parallel()
 	tests := []struct {

--- a/upgrade/upgrade_provider.go
+++ b/upgrade/upgrade_provider.go
@@ -55,13 +55,7 @@ func UpgradeProvider(ctx context.Context, repoOrg, repoName string) (err error) 
 
 	err = stepv2.PipelineCtx(ctx, "Discover Provider", func(ctx context.Context) {
 		repo.root = ensureRepoInCWD(ctx, repoName)
-		// If the user set --repo-path as CWD, assume all git content is already in-place; simply infer the main
-		// branch without pulling anything. Otherwise, pull.
-		if GetContext(ctx).IsCWD() {
-			repo.defaultBranch = findDefaultBranch(ctx, "origin")
-		} else {
-			repo.defaultBranch = pullDefaultBranch(ctx, "origin")
-		}
+		repo.defaultBranch = findDefaultBranch(ctx, "origin")
 		goMod = getRepoKind(ctx, repo)
 
 		// If we do not have the upstream provider org set in the .upgrade-config.yml, we infer it from the go mod path.

--- a/upgrade/upgrade_provider.go
+++ b/upgrade/upgrade_provider.go
@@ -54,7 +54,7 @@ func UpgradeProvider(ctx context.Context, repoOrg, repoName string) (err error) 
 	}
 
 	err = stepv2.PipelineCtx(ctx, "Discover Provider", func(ctx context.Context) {
-		repo.root = OrgProviderRepos(ctx, repoOrg, repoName)
+		repo.root = ensureRepoInCWD(ctx, repoName)
 		// If the user set --repo-path as CWD, assume all git content is already in-place; simply infer the main
 		// branch without pulling anything. Otherwise, pull.
 		if GetContext(ctx).IsCWD() {

--- a/upgrade/util.go
+++ b/upgrade/util.go
@@ -7,8 +7,6 @@ import (
 
 	"github.com/Masterminds/semver/v3"
 	"golang.org/x/mod/module"
-
-	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 )
 
 type contextKeyType struct{}
@@ -22,8 +20,6 @@ func GetContext(ctx context.Context) *Context {
 type Context struct {
 	// The user's GOPATH env var
 	GoPath string
-	// An optional path to clone the provider repo to
-	repoPath string
 
 	TargetVersion *semver.Version
 	InferVersion  bool
@@ -88,25 +84,8 @@ type Context struct {
 	PRTitlePrefix string
 }
 
-// Check if the user specified operating in the current working directory (CWD) with `--repo-path=.`. In this case the
-// tool can assume all Git fetching and sumbodule resolution has been done already by the user.
-func (c *Context) IsCWD() bool {
-	if c.repoPath == "" {
-		return false
-	}
-	cwd, err := filepath.Abs(".")
-	contract.AssertNoErrorf(err, "filepath.Abs failed unexpectedly")
-	rp, err := filepath.Abs(c.repoPath)
-	contract.AssertNoErrorf(err, "filepath.Abs failed unexpectedly")
-	return cwd == rp
-}
-
 func (c *Context) Wrap(ctx context.Context) context.Context {
 	return context.WithValue(ctx, contextKey, c)
-}
-
-func (c *Context) SetRepoPath(p string) {
-	c.repoPath = p
 }
 
 type HandledError struct{}


### PR DESCRIPTION
Removes the logic for using the tool when not inside the provider repo - we don't use it for our workflows and it likely doesn't work.