### PR TITLE
Separate out logic for checking upstream version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,6 @@ require (
 	github.com/spf13/viper v1.15.0
 	github.com/stretchr/testify v1.8.3
 	golang.org/x/mod v0.21.0
-	golang.org/x/tools v0.21.0
 	gopkg.in/yaml.v3 v3.0.1
 )
 
@@ -24,6 +23,7 @@ require (
 	github.com/nightlyone/lockfile v1.0.0 // indirect
 	github.com/rogpeppe/go-internal v1.11.0 // indirect
 	golang.org/x/sync v0.7.0 // indirect
+	golang.org/x/tools v0.21.0 // indirect
 	gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c // indirect
 	gopkg.in/ini.v1 v1.67.0 // indirect
 	mvdan.cc/gofumpt v0.5.0 // indirect

--- a/main.go
+++ b/main.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"go/build"
 	"os"
+	"slices"
 	"strconv"
 	"strings"
 
@@ -132,7 +133,6 @@ func cmd() *cobra.Command {
 						)
 					}
 					set(&context.UpgradeProviderVersion)
-					set(&context.OnlyCheckUpstream)
 
 				default:
 					return fmt.Errorf(
@@ -148,6 +148,11 @@ func cmd() *cobra.Command {
 			return nil
 		},
 		Run: func(_ *cobra.Command, args []string) {
+			if slices.Contains(upgradeKind, "check-upstream-version") {
+				exitOnError(upgrade.CheckUpstream(context.Wrap(ctx), repoOrg, repoName))
+				return
+			}
+
 			exitOnError(failedPreRun)
 			err := upgrade.UpgradeProvider(context.Wrap(ctx), repoOrg, repoName)
 			exitOnError(err)

--- a/upgrade/check_upstream.go
+++ b/upgrade/check_upstream.go
@@ -1,0 +1,66 @@
+package upgrade
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/pulumi/upgrade-provider/colorize"
+	stepv2 "github.com/pulumi/upgrade-provider/step/v2"
+)
+
+func CheckUpstream(ctx context.Context, repoOrg, repoName string) (err error) {
+	// Setup ctx to enable replay tests with stepv2:
+	if file := os.Getenv("PULUMI_REPLAY"); file != "" {
+		var write io.Closer
+		ctx, write = stepv2.WithRecord(ctx, file)
+		defer func() { err = errors.Join(err, write.Close()) }()
+	}
+
+	repo := ProviderRepo{
+		Name: repoName,
+		Org:  repoOrg,
+	}
+
+	var goMod *GoMod
+	var upgradeTarget *UpstreamUpgradeTarget
+
+	err = stepv2.PipelineCtx(ctx, "Set Up Environment", func(ctx context.Context) {
+		env := func(k, v string) { setEnv(ctx, k, v) }
+		env("GOWORK", "off")
+	})
+
+	err = stepv2.PipelineCtx(ctx, "Discover Provider", func(ctx context.Context) {
+		repo.root = ensureRepoInCWD(ctx, repoName)
+		repo.defaultBranch = findDefaultBranch(ctx, "origin")
+		goMod = getRepoKind(ctx, repo)
+
+		// If we do not have the upstream provider org set in the .upgrade-config.yml, we infer it from the go mod path.
+		if GetContext(ctx).UpstreamProviderOrg == "" {
+			GetContext(ctx).UpstreamProviderOrg = parseUpstreamProviderOrg(ctx, goMod.Upstream)
+		}
+		if GetContext(ctx).UpgradeProviderVersion {
+			upgradeTarget = planProviderUpgrade(ctx, repoOrg, repoName, goMod, &repo, true)
+		}
+	})
+	if err != nil {
+		return err
+	}
+
+	if GetContext(ctx).UpgradeProviderVersion {
+		pipelineName := fmt.Sprintf("New upstream version detected: v%s", upgradeTarget.Version)
+		return stepv2.PipelineCtx(ctx, pipelineName, func(ctx context.Context) {
+			createUpstreamUpgradeIssue(ctx,
+				repoOrg,
+				repoName,
+				upgradeTarget.Version.String(),
+			)
+		})
+
+	}
+	fmt.Println(colorize.Bold("No new upstream version detected. Everything up to date."))
+
+	return nil
+}

--- a/upgrade/steps.go
+++ b/upgrade/steps.go
@@ -728,10 +728,16 @@ func applyPulumiVersion(ctx context.Context, repo ProviderRepo) step.Step {
 //
 // That means figuring out the old and the new version, and producing a
 // UpstreamUpgradeTarget.
-var planProviderUpgrade = stepv2.Func41E("Plan Provider Upgrade", func(ctx context.Context,
-	repoOrg, repoName string, goMod *GoMod, repo *ProviderRepo,
+var planProviderUpgrade = stepv2.Func51E("Plan Provider Upgrade", func(ctx context.Context,
+	repoOrg, repoName string, goMod *GoMod, repo *ProviderRepo, forceLatest bool,
 ) (*UpstreamUpgradeTarget, error) {
-	upgradeTarget := getExpectedTarget(ctx, repoOrg+"/"+repoName)
+	var upgradeTarget *UpstreamUpgradeTarget
+	if forceLatest {
+		upgradeTarget = getExpectedTargetLatest(ctx)
+	} else {
+		upgradeTarget = getExpectedTarget(ctx, repoOrg+"/"+repoName)
+	}
+
 	if upgradeTarget == nil {
 		return nil, fmt.Errorf("could not determine an upstream version")
 	}

--- a/upgrade/steps_helpers.go
+++ b/upgrade/steps_helpers.go
@@ -453,12 +453,6 @@ var latestReleaseVersion = stepv2.Func12E("Latest Release Version",
 // The second argument represents a message to describe the result. It may be empty.
 var getExpectedTarget = stepv2.Func11("Get Expected Target", func(ctx context.Context,
 	name string) *UpstreamUpgradeTarget {
-
-	// we do not infer version from pulumi issues, or allow a target version when checking for a new upstream release
-	if GetContext(ctx).OnlyCheckUpstream {
-		return getExpectedTargetLatest(ctx)
-	}
-
 	if GetContext(ctx).TargetVersion != nil {
 		target := &UpstreamUpgradeTarget{Version: GetContext(ctx).TargetVersion}
 

--- a/upgrade/upgrade_provider.go
+++ b/upgrade/upgrade_provider.go
@@ -63,30 +63,11 @@ func UpgradeProvider(ctx context.Context, repoOrg, repoName string) (err error) 
 			GetContext(ctx).UpstreamProviderOrg = parseUpstreamProviderOrg(ctx, goMod.Upstream)
 		}
 		if GetContext(ctx).UpgradeProviderVersion {
-			upgradeTarget = planProviderUpgrade(ctx, repoOrg, repoName, goMod, &repo)
+			upgradeTarget = planProviderUpgrade(ctx, repoOrg, repoName, goMod, &repo, false)
 		}
 	})
 	if err != nil {
 		return err
-	}
-
-	// When we're running a version check, we create the upgrade issue, and then exit.
-	if GetContext(ctx).OnlyCheckUpstream {
-		// UpgradeProviderVersion may be set to False at this point. We check again.
-		if GetContext(ctx).UpgradeProviderVersion {
-			pipelineName := fmt.Sprintf("New upstream version detected: v%s", upgradeTarget.Version)
-			return stepv2.PipelineCtx(ctx, pipelineName, func(ctx context.Context) {
-				createUpstreamUpgradeIssue(ctx,
-					repoOrg,
-					repoName,
-					upgradeTarget.Version.String(),
-				)
-			})
-
-		}
-		fmt.Println(colorize.Bold("No new upstream version detected. Everything up to date."))
-
-		return nil
 	}
 
 	err = stepv2.PipelineCtx(ctx, "Plan Upgrade", func(ctx context.Context) {

--- a/upgrade/util.go
+++ b/upgrade/util.go
@@ -23,9 +23,6 @@ type Context struct {
 
 	TargetVersion *semver.Version
 	InferVersion  bool
-	// For CI - check and see if upstream is ahead of this provider.
-	// If so, create a GH issue and exit. Do not attempt to upgrade the provider.
-	OnlyCheckUpstream bool
 
 	UpgradeBridgeVersion bool
 	TargetBridgeRef      Ref


### PR DESCRIPTION
`upgrade-provider` is actually used in two ways:
1. As a tool to check the upstream repo for new versions and open a corresponding GH issue (`check-upstream-version`)
2. As a tool to upgrade the provider

Previously the logic for the two uses was intertwined making reasoning about consequences more difficult. This PR separates them into two function calls.