### PR TITLE
Remove logic for inferring current upstream version - use a file to record it instead

### DIFF
--- a/upgrade/check_upstream.go
+++ b/upgrade/check_upstream.go
@@ -7,11 +7,12 @@ import (
 	"io"
 	"os"
 
+	semver "github.com/Masterminds/semver/v3"
 	"github.com/pulumi/upgrade-provider/colorize"
 	stepv2 "github.com/pulumi/upgrade-provider/step/v2"
 )
 
-func CheckUpstream(ctx context.Context, repoOrg, repoName string) (err error) {
+func CheckUpstream(ctx context.Context, repoOrg, repoName string, currentUpstreamVersion *semver.Version) (err error) {
 	// Setup ctx to enable replay tests with stepv2:
 	if file := os.Getenv("PULUMI_REPLAY"); file != "" {
 		var write io.Closer
@@ -20,8 +21,9 @@ func CheckUpstream(ctx context.Context, repoOrg, repoName string) (err error) {
 	}
 
 	repo := ProviderRepo{
-		Name: repoName,
-		Org:  repoOrg,
+		Name:                   repoName,
+		Org:                    repoOrg,
+		currentUpstreamVersion: currentUpstreamVersion,
 	}
 
 	var goMod *GoMod

--- a/upgrade/steps.go
+++ b/upgrade/steps.go
@@ -749,50 +749,31 @@ var planProviderUpgrade = stepv2.Func51E("Plan Provider Upgrade", func(ctx conte
 		return nil, nil
 	}
 
-	switch {
-	case goMod.Kind.IsPatched():
-		setCurrentUpstreamFromPatched(ctx, repo)
-	case goMod.Kind.IsShimmed():
-		setCurrentUpstreamFromShimmed(ctx, repo, goMod)
-	case goMod.Kind == Plain:
-		setCurrentUpstreamFromPlain(ctx, repo, goMod)
-	default:
-		return nil, fmt.Errorf("unexpected repo kind: %s", goMod.Kind)
-	}
-
-	// If we have a target version, we need to make sure that
-	// it is valid for an upgrade.
 	var msg string
-	if repo.currentUpstreamVersion != nil {
-		switch goSemver.Compare("v"+repo.currentUpstreamVersion.String(),
-			"v"+upgradeTarget.Version.String()) {
+	switch goSemver.Compare("v"+repo.currentUpstreamVersion.String(),
+		"v"+upgradeTarget.Version.String()) {
 
-		// Target version is less then the current version
-		case 1:
-			// This is a weird situation, so we warn
-			msg = colorize.Warnf(
-				" no upgrade: %s (current) > %s (target)",
-				repo.currentUpstreamVersion,
-				upgradeTarget.Version)
-			GetContext(ctx).UpgradeProviderVersion = false
-			GetContext(ctx).MajorVersionBump = false
+	// Target version is less then the current version
+	case 1:
+		// This is a weird situation, so we warn
+		msg = colorize.Warnf(
+			" no upgrade: %s (current) > %s (target)",
+			repo.currentUpstreamVersion,
+			upgradeTarget.Version)
+		GetContext(ctx).UpgradeProviderVersion = false
+		GetContext(ctx).MajorVersionBump = false
 
-		// Target version is equal to the current version
-		case 0:
-			GetContext(ctx).UpgradeProviderVersion = false
-			GetContext(ctx).MajorVersionBump = false
-			msg = "Up to date"
+	// Target version is equal to the current version
+	case 0:
+		GetContext(ctx).UpgradeProviderVersion = false
+		GetContext(ctx).MajorVersionBump = false
+		msg = "Up to date"
 
-		// Target version is greater than the current version, so upgrade
-		case -1:
-			msg = fmt.Sprintf("%s -> %s",
-				repo.currentUpstreamVersion,
-				upgradeTarget.Version)
-		}
-	} else {
-		// If we don't have an old version, just assume
-		// that we will upgrade.
-		msg = upgradeTarget.Version.String()
+	// Target version is greater than the current version, so upgrade
+	case -1:
+		msg = fmt.Sprintf("%s -> %s",
+			repo.currentUpstreamVersion,
+			upgradeTarget.Version)
 	}
 
 	stepv2.SetLabel(ctx, msg)


### PR DESCRIPTION
This PR removes the logic for inferring the current upstream version. That logic adds unnecessary complexity as the repo should know that information.

Instead of that we will now record the version in the `.upgrade-config.yml` file in each provider repo. That will be bumped each time we make an upgrade by `upgrade-provider`.