### PR TITLE
remove logic for inferring upstream org

### DIFF
--- a/main.go
+++ b/main.go
@@ -91,6 +91,10 @@ func cmd() *cobra.Command {
 				return fmt.Errorf(`"upstream-provider-name" must not be fully qualified%s`, s)
 			}
 
+			if context.UpstreamProviderOrg == "" {
+				return errors.New("`upstream-provider-org` must be provided")
+			}
+
 			if currentUpstreamVersion == "" {
 				return errors.New("`current-upstream-version` must be provided")
 			}

--- a/upgrade/check_upstream.go
+++ b/upgrade/check_upstream.go
@@ -39,10 +39,6 @@ func CheckUpstream(ctx context.Context, repoOrg, repoName string, currentUpstrea
 		repo.defaultBranch = findDefaultBranch(ctx, "origin")
 		goMod = getRepoKind(ctx, repo)
 
-		// If we do not have the upstream provider org set in the .upgrade-config.yml, we infer it from the go mod path.
-		if GetContext(ctx).UpstreamProviderOrg == "" {
-			GetContext(ctx).UpstreamProviderOrg = parseUpstreamProviderOrg(ctx, goMod.Upstream)
-		}
 		if GetContext(ctx).UpgradeProviderVersion {
 			upgradeTarget = planProviderUpgrade(ctx, repoOrg, repoName, goMod, &repo, true)
 		}

--- a/upgrade/steps.go
+++ b/upgrade/steps.go
@@ -905,20 +905,3 @@ var fetchLatestJavaGen = stepv2.Func03("Fetching latest Java Gen", func(ctx cont
 	stepv2.SetLabel(ctx, latestJavaGen.String())
 	return currentJavaGen, latestJavaGen.String(), true
 })
-
-var parseUpstreamProviderOrg = stepv2.Func11E("Get UpstreamOrg from module version", func(ctx context.Context, upstreamMod module.Version) (string, error) {
-	// We expect tokens to be of the form:
-	//
-	//	github.com/${org}/${repo}/${path}
-	//
-	// The second chunk is the org name.
-
-	// Verify that the token is of valid format
-	goModRegexp := regexp.MustCompile("[a-zA-Z0-9-.]*/[a-zA-Z0-9-_.]*/[a-zA-Z0-9-]*")
-
-	if !goModRegexp.MatchString(upstreamMod.Path) {
-		return "", fmt.Errorf("invalid upstream module format: expected format github.com/${org}/${repo}/${path} but got %s", upstreamMod.Path)
-	}
-	tok := strings.Split(modPathWithoutVersion(upstreamMod.Path), "/")
-	return tok[1], nil
-})

--- a/upgrade/steps_test.go
+++ b/upgrade/steps_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/Masterminds/semver/v3"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"golang.org/x/mod/module"
 
 	"github.com/pulumi/upgrade-provider/step/v2"
 )
@@ -278,94 +277,6 @@ func TestReleaseLabel(t *testing.T) {
 			assert.NoError(t, err)
 		})
 	}
-}
-
-func TestUpstreamGoModRegexp(t *testing.T) {
-	t.Parallel()
-	tests := []struct {
-		name     string
-		input    module.Version
-		expected string
-	}{
-		{
-			name: "Gets plain upstream org name with v1 provider format",
-			input: module.Version{
-				Path: "github.com/unicornio/terraform-provider-foo",
-			},
-			expected: "unicornio",
-		},
-		{
-			name: "Gets allowed chars in upstream org name with v1 provider format",
-			input: module.Version{
-				Path: "github.com/uniCorn_12-io/terraform-provider-foo",
-			},
-			expected: "uniCorn_12-io",
-		},
-		{
-			name: "Gets plain upstream org name with v2+ provider format",
-			input: module.Version{
-				Path: "github.com/unicornio/terraform-provider-foo/v2",
-			},
-			expected: "unicornio",
-		},
-		{
-			name: "Gets allowed chars in upstream org name with v2+ provider format",
-			input: module.Version{
-				Path: "github.com/uniCorn_12-io/terraform-provider-foo/v45",
-			},
-			expected: "uniCorn_12-io",
-		},
-		{
-			name: "Gets non-GitHub hosted module name",
-			input: module.Version{
-				Path: "gitlab.com/unicornio/terraform-provider-foo/v2",
-			},
-			expected: "unicornio",
-		},
-		{
-			name: "Errors on invalid path",
-			input: module.Version{
-				Path: "terraform-provider-foo",
-			},
-			expected: "",
-		},
-	}
-	for _, tt := range tests {
-		tt := tt
-		t.Run(tt.name, func(t *testing.T) {
-			err := step.Pipeline("test", func(ctx context.Context) {
-				actual := parseUpstreamProviderOrg(ctx, tt.input)
-				assert.Equal(t, tt.expected, actual)
-			})
-			if tt.name == "Errors on invalid path" {
-				assert.Error(t, err)
-			} else {
-				assert.NoError(t, err)
-			}
-		})
-	}
-}
-
-func TestParseUpstreamProviderOrgFromModVersion(t *testing.T) {
-	testReplay((&Context{
-		GoPath:               "/Users/myuser/go",
-		UpstreamProviderName: "terraform-provider-datadog",
-		UpstreamProviderOrg:  "",
-	}).Wrap(context.Background()), t, jsonMarshal[[]*step.Step](t, `[
-	{
-          "name": "Get UpstreamOrg from module version",
-          "inputs": [
-            {
-              "Path": "github.com/testing-org/terraform-provider-datadog",
-              "Version": "v0.0.0"
-            }
-          ],
-          "outputs": [
-            "testing-org",
-            null
-          ]
-        }
-]`), "Get UpstreamOrg from module version", parseUpstreamProviderOrg)
 }
 
 func TestCheckMaintenancePatchWithinCadence(t *testing.T) {

--- a/upgrade/upgrade_provider.go
+++ b/upgrade/upgrade_provider.go
@@ -61,10 +61,6 @@ func UpgradeProvider(ctx context.Context, repoOrg, repoName string, currentUpstr
 		repo.defaultBranch = findDefaultBranch(ctx, "origin")
 		goMod = getRepoKind(ctx, repo)
 
-		// If we do not have the upstream provider org set in the .upgrade-config.yml, we infer it from the go mod path.
-		if GetContext(ctx).UpstreamProviderOrg == "" {
-			GetContext(ctx).UpstreamProviderOrg = parseUpstreamProviderOrg(ctx, goMod.Upstream)
-		}
 		if GetContext(ctx).UpgradeProviderVersion {
 			upgradeTarget = planProviderUpgrade(ctx, repoOrg, repoName, goMod, &repo, false)
 		}

--- a/upgrade/util.go
+++ b/upgrade/util.go
@@ -46,15 +46,7 @@ type Context struct {
 	UpstreamProviderName string
 	// The org component in the upstream provider's repo path.
 	//
-	// This must be provided when upstream is hosted at a repo that does
-	// not match the Go Module path it is declared as. Otherwise it can
-	// be inferred.
-	//
-	// For example, if we have an upstream provider with import path:
-	//
-	//	github.com/terraform-providers/terraform-provider-my-provider
-	//
-	// which is hosted at:
+	// For example, if the upstream provider is hosted at:
 	//
 	//	github.com/my-org/terraform-provider-my-provider
 	//


### PR DESCRIPTION
That is unnecessary and can be replaced by a config in `upgrade-config.yml`. This also makes it easier to change the configuration when upstream repos move between organizations.