### PR TITLE
add --dry-run flag to enable testing

### DIFF
--- a/main.go
+++ b/main.go
@@ -245,6 +245,9 @@ This is equivalent to setting PULUMI_MISSING_DOCS_ERROR=${! VALUE}.`)
 	cmd.PersistentFlags().StringVar(&context.PRTitlePrefix, "pr-title-prefix", "",
 		`The prefix to insert in the generated pull request title.`)
 
+	cmd.PersistentFlags().BoolVar(&context.DryRun, "dry-run", false,
+		`If true, don't actually create any PRs.`)
+
 	return cmd
 }
 

--- a/upgrade/steps.go
+++ b/upgrade/steps.go
@@ -192,6 +192,11 @@ var InformGitHub = stepv2.Func60E("Inform Github", func(
 	ctx = stepv2.WithEnv(ctx, &stepv2.SetCwd{To: repo.root})
 	c := GetContext(ctx)
 
+	if c.DryRun {
+		stepv2.SetLabel(ctx, "Dry run: skipping git push and PR creation")
+		return nil
+	}
+
 	// --force:
 	//
 	// If there is no existing branch, then --force doesn't have any effect. It is thus safe.

--- a/upgrade/upgrade_provider.go
+++ b/upgrade/upgrade_provider.go
@@ -321,6 +321,9 @@ func BumpRecordedUpstreamVersion(ctx context.Context, version *semver.Version, c
 
 		stepv2.Cmd(ctx, "git", "add", configFile)
 		stepv2.Cmd(ctx, "git", "commit", "-m", fmt.Sprintf("Bump recorded upstream version to %s", version.String()))
+		if GetContext(ctx).DryRun {
+			return
+		}
 		stepv2.Cmd(ctx, "git", "push")
 	})
 }

--- a/upgrade/util.go
+++ b/upgrade/util.go
@@ -68,6 +68,9 @@ type Context struct {
 
 	PRDescription string
 	PRTitlePrefix string
+
+	// If true, don't actually create any PRs.
+	DryRun bool
 }
 
 func (c *Context) Wrap(ctx context.Context) context.Context {


### PR DESCRIPTION
Adds a `--dry-run` flag which will do all the steps except pushing the branch and opening a PR. This is essential for end-to-end tests.