### PR TITLE
Remove maintenance release logic

### DIFF
--- a/upgrade/check_upstream.go
+++ b/upgrade/check_upstream.go
@@ -8,6 +8,7 @@ import (
 	"os"
 
 	semver "github.com/Masterminds/semver/v3"
+
 	"github.com/pulumi/upgrade-provider/colorize"
 	stepv2 "github.com/pulumi/upgrade-provider/step/v2"
 )

--- a/upgrade/steps_test.go
+++ b/upgrade/steps_test.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"os"
 	"testing"
-	"time"
 
 	"github.com/Masterminds/semver/v3"
 	"github.com/stretchr/testify/assert"
@@ -277,82 +276,6 @@ func TestReleaseLabel(t *testing.T) {
 			assert.NoError(t, err)
 		})
 	}
-}
-
-func TestCheckMaintenancePatchWithinCadence(t *testing.T) {
-	fourWeeksAgo := time.Now().Add(-time.Hour * 24 * 7 * 4).Format(time.RFC3339)
-	testReplay((&Context{
-		GoPath: "/Users/myuser/go",
-	}).Wrap(context.Background()),
-		t, jsonMarshal[[]*step.Step](t, `[
-	{
-          "name": "Check if we should release a maintenance patch",
-          "inputs": [
-            {
-				"Org":  "pulumi",
-				"Name": "pulumi-cloudinit"
-			}
-          ],
-          "outputs": [
-            false,
-	    null
-          ]
-        },
-        {
-          "name": "gh",
-          "inputs": [
-            "gh",
-            [
-              "repo",
-              "view",
-              "pulumi/pulumi-cloudinit",
-              "--json=latestRelease"
-            ]
-          ],
-          "outputs": [
-            "{\"latestRelease\":{\"name\":\"v1.4.0\",\"tagName\":\"v1.4.0\",\"url\":\"https://github.com/pulumi/pulumi-cloudinit/releases/tag/v1.4.0\",\"publishedAt\":\"`+fourWeeksAgo+`\"}}\n",
-            null
-          ],
-          "impure": true
-        }
-]`), "Check if we should release a maintenance patch", maintenanceRelease)
-}
-
-func TestCheckMaintenancePatchExpiredCadence(t *testing.T) {
-	testReplay((&Context{
-		GoPath: "/Users/myuser/go",
-	}).Wrap(context.Background()),
-		t, jsonMarshal[[]*step.Step](t, `[
-	{
-          "name": "Check if we should release a maintenance patch",
-          "inputs": [
-            {
-				"Org":  "pulumi",
-				"Name": "pulumi-cloudinit"
-			}
-          ],
-          "outputs": [
-            true,
-			null
-          ]
-        },
-        {
-          "name": "gh",
-          "inputs": [
-            "gh",
-            [
-              "repo",
-              "view",
-              "pulumi/pulumi-cloudinit",
-              "--json=latestRelease"
-            ]
-          ],
-          "outputs": [
-			"{\"latestRelease\":{\"name\":\"v1.4.0\",\"tagName\":\"v1.4.0\",\"url\":\"https://github.com/pulumi/pulumi-cloudinit/releases/tag/v1.4.0\",\"publishedAt\":\"2023-01-04T21:03:48Z\"}}\n",            null
-          ],
-          "impure": true
-        }
-]`), "Check if we should release a maintenance patch", maintenanceRelease)
 }
 
 func TestPluginSDKUpgrade(t *testing.T) {

--- a/upgrade/upgrade_provider.go
+++ b/upgrade/upgrade_provider.go
@@ -79,8 +79,6 @@ func UpgradeProvider(
 				tbv := targetBridgeVersion.String()
 				tfSDKTargetSHA, tfSDKUpgrade = planPluginSDKUpgrade(ctx, tbv)
 			}
-			// Check if we need to release a maintenance patch and set context if so
-			GetContext(ctx).MaintenancePatch = maintenanceRelease(ctx, repo)
 		}
 
 		if GetContext(ctx).MajorVersionBump {

--- a/upgrade/util.go
+++ b/upgrade/util.go
@@ -29,11 +29,6 @@ type Context struct {
 
 	UpgradeJavaVersion bool
 
-	// Some providers go for months without an upstream release, but do receive weekly bridge updates.
-	// upgrade-provider will detect if the provider's last release is more than eight weeks old, and if it is,
-	// setting this field to True will trigger a patch release on a non-upstream upgrade.
-	MaintenancePatch bool
-
 	// The unqualified name of the upstream provider.
 	//
 	// As an example, Pulumi's AWS provider has:


### PR DESCRIPTION
We have some logic for releasing a provider if it hasn't been released in a while. It doesn't really belong here and should be a cron job instead.

Opened https://github.com/pulumi/ci-mgmt/issues/1606 to follow-up on the cron job.