### PR TITLE
Remove bridge version inference

### DIFF
--- a/upgrade/kind.go
+++ b/upgrade/kind.go
@@ -73,14 +73,6 @@ var getRepoKind = stepv2.Func11E("Get Repo Kind", func(ctx context.Context, repo
 		return nil, fmt.Errorf("go.mod: %w", err)
 	}
 
-	bridge, ok, err := originalGoVersionOf(ctx, repo, filepath.Join("provider", "go.mod"), "github.com/pulumi/pulumi-terraform-bridge")
-	bridgeMissingMsg := "Unable to discover pulumi-terraform-bridge version"
-	if err != nil {
-		return nil, fmt.Errorf("%s: %w", bridgeMissingMsg, err)
-	} else if !ok {
-		return nil, fmt.Errorf("%s", bridgeMissingMsg)
-	}
-
 	tfProviderRepoName := GetContext(ctx).UpstreamProviderName
 
 	getUpstream := func(file *modfile.File) (*modfile.Require, error) {
@@ -126,7 +118,6 @@ var getRepoKind = stepv2.Func11E("Get Repo Kind", func(ctx context.Context, repo
 
 	out := GoMod{
 		Upstream: upstream.Mod,
-		Bridge:   bridge,
 	}
 
 	out.Kind = Plain

--- a/upgrade/util.go
+++ b/upgrade/util.go
@@ -7,6 +7,8 @@ import (
 
 	"github.com/Masterminds/semver/v3"
 	"golang.org/x/mod/module"
+
+	stepv2 "github.com/pulumi/upgrade-provider/step/v2"
 )
 
 type contextKeyType struct{}
@@ -169,4 +171,16 @@ func latestSemverTag(prefix string, refs gitRepoRefs) *semver.Version {
 	}
 	v, _ := semver.NewVersion(trim(sorted[0]))
 	return v
+}
+
+func readFileWithoutLine(ctx context.Context, path string, lineToSkip string) string {
+	content := stepv2.ReadFile(ctx, path)
+	lines := strings.Split(content, "\n")
+	var newLines []string
+	for _, line := range lines {
+		if line != lineToSkip {
+			newLines = append(newLines, line)
+		}
+	}
+	return strings.Join(newLines, "\n")
 }


### PR DESCRIPTION
Remove the logic for inferring the current bridge version, similar to the upstream provider version. It is now recorded in the upgrade config and controlled from there.