### PR TITLE
Fix GITHUB_OUTPUT env var version writing

### DIFF
--- a/upgrade/steps_helpers.go
+++ b/upgrade/steps_helpers.go
@@ -652,14 +652,14 @@ var createUpstreamUpgradeIssue = stepv2.Func30E("Ensure Upstream Issue", func(ct
 		return err
 	}
 
-	// Write issue_created=true to GITHUB_OUTPUT, if it exists for CI control flow.
+	// Write latest_version=$VERSION to GITHUB_OUTPUT, if it exists for CI control flow.
 	if GITHUB_OUTPUT, found := os.LookupEnv("GITHUB_OUTPUT"); found {
 		f, err := os.OpenFile(GITHUB_OUTPUT, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
 		if err != nil {
 			return err
 		}
 		defer f.Close()
-		if _, err := fmt.Fprintf(f, "issue_created=true\n"); err != nil {
+		if _, err := fmt.Fprintf(f, "latest_version=%s\n", version); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
This broke in https://github.com/pulumi/upgrade-provider/pull/324/files#diff-c087d06c8ac41b92d7d08be4ca7a169cdae614b8670f1a270e2c5343c1f16035 and none of our upgrades are going through because of that.

The comment was wrong and this must have been an accidental change with an LLM. Missed this in the last PR.

The behaviour is also quite sneaky, I'll look into making it a bit more explicit in the Github workflow.

fixes https://github.com/pulumi/upgrade-provider/issues/343