### PR TITLE
Expose the ability to upgrade Java exclusively

### DIFF
--- a/main.go
+++ b/main.go
@@ -101,7 +101,7 @@ func cmd() *cobra.Command {
 			// This can happen by calling `upgrade-provider --kind=""`
 			if len(upgradeKind) == 0 {
 				return fmt.Errorf("--kind=\"\" is invalid. Must be one of `all`, " +
-					"`bridge`, `provider`, or `pulumi`")
+					"`bridge`, `provider`, `java`, or `pulumi`")
 			}
 
 			// Validate the kind switch
@@ -125,6 +125,9 @@ func cmd() *cobra.Command {
 					set(&context.UpgradeBridgeVersion)
 				case "provider":
 					set(&context.UpgradeProviderVersion)
+				case "java":
+					context.UpgradeJavaVersion = true
+					context.UpgradeJavaVersionOnly = true
 				case "pulumi":
 				case "check-upstream-version":
 					if targetVersion != "" {

--- a/upgrade/upgrade_provider.go
+++ b/upgrade/upgrade_provider.go
@@ -296,7 +296,12 @@ func tfgenAndBuildSDKs(
 		stepv2.Cmd(ctx, "git", "add", "--all")
 		gitCommit(ctx, "make tfgen")
 
-		stepv2.Cmd(ctx, "make", "generate_sdks")
+		gen := "generate_sdks"
+		if GetContext(ctx).UpgradeJavaVersionOnly {
+			gen = "generate_java"
+		}
+
+		stepv2.Cmd(ctx, "make", gen)
 
 		// Update sdk/go.mod's module after rebuilding the go SDK
 		if GetContext(ctx).MajorVersionBump {
@@ -318,7 +323,7 @@ func tfgenAndBuildSDKs(
 
 		stepv2.Cmd(ctx, "git", "add", "--all")
 
-		gitCommit(ctx, "make generate_sdks")
+		gitCommit(ctx, fmt.Sprintf("make %s", gen))
 
 		InformGitHub(ctx, upgradeTarget, repo, goMod, targetBridgeVersion, tfSDKUpgrade, os.Args)
 	}

--- a/upgrade/util.go
+++ b/upgrade/util.go
@@ -37,7 +37,8 @@ type Context struct {
 	UpgradeProviderVersion bool
 	MajorVersionBump       bool
 
-	UpgradeJavaVersion bool
+	UpgradeJavaVersion     bool
+	UpgradeJavaVersionOnly bool
 
 	// Some providers go for months without an upstream release, but do receive weekly bridge updates.
 	// upgrade-provider will detect if the provider's last release is more than eight weeks old, and if it is,


### PR DESCRIPTION
This seems to work well enough - see 3 examples in https://github.com/pulumi/ci-mgmt/issues/1611 