### PR TITLE
Remove PULUMI_EXTRA_MAPPING_ERROR

### DIFF
--- a/upgrade/testdata/replay/gcp_noop_bridge_update.json
+++ b/upgrade/testdata/replay/gcp_noop_bridge_update.json
@@ -24,17 +24,6 @@
             null
           ],
           "impure": true
-        },
-        {
-          "name": "PULUMI_EXTRA_MAPPING_ERROR=true",
-          "inputs": [
-            "PULUMI_EXTRA_MAPPING_ERROR",
-            "true"
-          ],
-          "outputs": [
-            null
-          ],
-          "impure": true
         }
       ]
     },

--- a/upgrade/upgrade_provider.go
+++ b/upgrade/upgrade_provider.go
@@ -47,7 +47,6 @@ func UpgradeProvider(ctx context.Context, repoOrg, repoName string) (err error) 
 			}
 			return "true"
 		}())
-		env("PULUMI_EXTRA_MAPPING_ERROR", "true")
 	})
 	if err != nil {
 		return err


### PR DESCRIPTION
This is now implemented by default in the bridge: https://github.com/pulumi/pulumi-terraform-bridge/pull/3144

We will now always error on an extra mapping error. It is no longer needed here.
