### PR TITLE
Revert "Remove logic for current directory - it should always be the provider repo (#327)"

### DIFF
--- a/main.go
+++ b/main.go
@@ -100,7 +100,7 @@ func cmd() *cobra.Command {
 			// This can happen by calling `upgrade-provider --kind=""`
 			if len(upgradeKind) == 0 {
 				return fmt.Errorf("--kind=\"\" is invalid. Must be one of `all`, " +
-					"`bridge`, `provider`, `java`, or `pulumi`")
+					"`bridge`, `provider`, or `pulumi`")
 			}
 
 			// Validate the kind switch
@@ -124,9 +124,6 @@ func cmd() *cobra.Command {
 					set(&context.UpgradeBridgeVersion)
 				case "provider":
 					set(&context.UpgradeProviderVersion)
-				case "java":
-					context.UpgradeJavaVersion = true
-					context.UpgradeJavaVersionOnly = true
 				case "pulumi":
 				case "check-upstream-version":
 					if targetVersion != "" {

--- a/step/v2/util.go
+++ b/step/v2/util.go
@@ -6,7 +6,6 @@ import (
 	"io/fs"
 	"os"
 	"os/exec"
-	"strings"
 )
 
 // Name a value so it is viable to the user.
@@ -45,12 +44,6 @@ func Cmd(ctx context.Context, name string, args ...string) string {
 		if exit, ok := err.(*exec.ExitError); ok {
 			err = fmt.Errorf("%s:\n%s", err.Error(), string(exit.Stderr))
 		}
-
-		if err != nil {
-			prettyCmd := strings.Join(append([]string{name}, args...), " ")
-			err = fmt.Errorf("upgrade-provider executed `%s` which failed: %w", prettyCmd, err)
-		}
-
 		return string(out), err
 	})(ctx, name, args)
 }

--- a/upgrade/upgrade_provider.go
+++ b/upgrade/upgrade_provider.go
@@ -289,12 +289,7 @@ func tfgenAndBuildSDKs(
 		stepv2.Cmd(ctx, "git", "add", "--all")
 		gitCommit(ctx, "make tfgen")
 
-		gen := "generate_sdks"
-		if GetContext(ctx).UpgradeJavaVersionOnly {
-			gen = "generate_java"
-		}
-
-		stepv2.Cmd(ctx, "make", gen)
+		stepv2.Cmd(ctx, "make", "generate_sdks")
 
 		// Update sdk/go.mod's module after rebuilding the go SDK
 		if GetContext(ctx).MajorVersionBump {
@@ -316,7 +311,7 @@ func tfgenAndBuildSDKs(
 
 		stepv2.Cmd(ctx, "git", "add", "--all")
 
-		gitCommit(ctx, fmt.Sprintf("make %s", gen))
+		gitCommit(ctx, "make generate_sdks")
 
 		InformGitHub(ctx, upgradeTarget, repo, goMod, targetBridgeVersion, tfSDKUpgrade, os.Args)
 	}

--- a/upgrade/util.go
+++ b/upgrade/util.go
@@ -33,8 +33,7 @@ type Context struct {
 	UpgradeProviderVersion bool
 	MajorVersionBump       bool
 
-	UpgradeJavaVersion     bool
-	UpgradeJavaVersionOnly bool
+	UpgradeJavaVersion bool
 
 	// Some providers go for months without an upstream release, but do receive weekly bridge updates.
 	// upgrade-provider will detect if the provider's last release is more than eight weeks old, and if it is,


### PR DESCRIPTION
Part of #351


This reverts commit e7b2015ff5375290b2ccb5076304511d67b60ec9, reversing
changes made to 81f7e72d036174e0990e625ed3b72fc256e97bea.
