### PR TITLE
Remove Java update automation

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,6 @@ require (
 	github.com/spf13/viper v1.15.0
 	github.com/stretchr/testify v1.8.3
 	golang.org/x/mod v0.21.0
-	golang.org/x/tools v0.21.0
 	gopkg.in/yaml.v3 v3.0.1
 )
 
@@ -24,6 +23,7 @@ require (
 	github.com/nightlyone/lockfile v1.0.0 // indirect
 	github.com/rogpeppe/go-internal v1.11.0 // indirect
 	golang.org/x/sync v0.7.0 // indirect
+	golang.org/x/tools v0.21.0 // indirect
 	gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c // indirect
 	gopkg.in/ini.v1 v1.67.0 // indirect
 	mvdan.cc/gofumpt v0.5.0 // indirect

--- a/main.go
+++ b/main.go
@@ -101,7 +101,7 @@ func cmd() *cobra.Command {
 			// This can happen by calling `upgrade-provider --kind=""`
 			if len(upgradeKind) == 0 {
 				return fmt.Errorf("--kind=\"\" is invalid. Must be one of `all`, " +
-					"`bridge`, `provider`, `java`, or `pulumi`")
+					"`bridge`, `provider`, or `pulumi`")
 			}
 
 			// Validate the kind switch
@@ -125,9 +125,6 @@ func cmd() *cobra.Command {
 					set(&context.UpgradeBridgeVersion)
 				case "provider":
 					set(&context.UpgradeProviderVersion)
-				case "java":
-					context.UpgradeJavaVersion = true
-					context.UpgradeJavaVersionOnly = true
 				case "pulumi":
 				case "check-upstream-version":
 					if targetVersion != "" {
@@ -162,11 +159,6 @@ func cmd() *cobra.Command {
 
 	pulumiDev, _ := strconv.ParseBool(os.Getenv("PULUMI_DEV"))
 
-	cmd.PersistentFlags().BoolVar(&context.UpgradeJavaVersion, "upgrade-java", false,
-		`Upgrade to the latest Java version`)
-	err := cmd.PersistentFlags().MarkHidden("upgrade-java")
-	contract.AssertNoErrorf(err, "could not mark `upgrade-java` flag as hidden")
-
 	cmd.PersistentFlags().StringVar(&repoPath, "repo-path", "",
 		`Clone the provider repo to the specified path. Skip cloning if set to "."`)
 
@@ -186,7 +178,7 @@ If both '--target-version' and '--pulumi-infer-version' are passed,
 we take '--target-version' to cap the inferred version. [Hidden behind PULUMI_DEV]`)
 
 	if !pulumiDev {
-		err = cmd.PersistentFlags().MarkHidden("pulumi-infer-version")
+		err := cmd.PersistentFlags().MarkHidden("pulumi-infer-version")
 		contract.AssertNoErrorf(err, "could not mark `pulumi-infer-version` flag as hidden")
 	}
 
@@ -221,9 +213,6 @@ Required unless running from provider root and set in upgrade-config.yml.`)
 	cmd.PersistentFlags().BoolVarP(&context.AllowMissingDocs, "allow-missing-docs", "", false,
 		`If true, don't error on missing docs during tfgen.
 This is equivalent to setting PULUMI_MISSING_DOCS_ERROR=${! VALUE}.`)
-
-	cmd.PersistentFlags().StringVar(&context.JavaVersion, "java-version", "",
-		"The version of pulumi-java-gen to target.")
 
 	context.TargetBridgeRef = &upgrade.Latest{} // Set default
 	cmd.PersistentFlags().VarP(upgrade.RefFlag(&context.TargetBridgeRef), "target-bridge-version", "",

--- a/upgrade/steps_helpers.go
+++ b/upgrade/steps_helpers.go
@@ -144,8 +144,6 @@ func prTitle(ctx context.Context, target *UpstreamUpgradeTarget, targetBridgeVer
 		title += "Upgrade pulumi-terraform-bridge to " + targetBridgeVersion.String()
 	case c.TargetPulumiVersion != nil:
 		title += "Test: Upgrade pulumi/{pkg,sdk} to " + c.TargetPulumiVersion.String()
-	case c.UpgradeJavaVersion:
-		title += "Upgrade pulumi-java to " + c.JavaVersion
 	default:
 		return "", fmt.Errorf("unknown action")
 	}
@@ -176,13 +174,6 @@ func prBody(ctx context.Context, repo ProviderRepo,
 
 	if GetContext(ctx).MajorVersionBump {
 		fmt.Fprintf(b, "- Updating major version from %s to %s.\n", repo.currentVersion, repo.currentVersion.IncMajor())
-	}
-	if ctx := GetContext(ctx); ctx.UpgradeJavaVersion && ctx.JavaVersion != "" {
-		var from string
-		if prev := ctx.oldJavaVersion; prev != "" {
-			from = fmt.Sprintf("from %s ", prev)
-		}
-		fmt.Fprintf(b, "- Updating Java Gen version %sto %s.\n", from, ctx.JavaVersion)
 	}
 
 	if GetContext(ctx).UpgradeProviderVersion {

--- a/upgrade/util.go
+++ b/upgrade/util.go
@@ -37,9 +37,6 @@ type Context struct {
 	UpgradeProviderVersion bool
 	MajorVersionBump       bool
 
-	UpgradeJavaVersion     bool
-	UpgradeJavaVersionOnly bool
-
 	// Some providers go for months without an upstream release, but do receive weekly bridge updates.
 	// upgrade-provider will detect if the provider's last release is more than eight weeks old, and if it is,
 	// setting this field to True will trigger a patch release on a non-upstream upgrade.
@@ -75,11 +72,6 @@ type Context struct {
 	//
 	// Otherwise, we will `replace` with TargetPulumiVersion for both pkg and sdk.
 	TargetPulumiVersion Ref
-
-	// The desired java version.
-	JavaVersion string
-	// The old java version we found.
-	oldJavaVersion string
 
 	AllowMissingDocs bool
 	PrReviewers      string


### PR DESCRIPTION
We will generate Java via the pulumi package gen-sdk command. Therefore, updates to the Java version file are no longer necessary.

Removes all Java functionality from this tool.

This is a BREAKING CHANGE and we may wish to keep this functionality; however, Javagen for bridged providers will be run via bridge language now.

