### PR TITLE
Fix: Chain string replacements in major version import updates

### DIFF
--- a/upgrade/steps.go
+++ b/upgrade/steps.go
@@ -649,7 +649,7 @@ var majorVersionBump = stepv2.Func30("Increment Major Version", func(
 					goMod.Upstream.Path); ok && major != "" {
 					newUpstream := fmt.Sprintf("%s/v%d",
 						prefix, target.Version.Major())
-					new = strings.ReplaceAll(data,
+					new = strings.ReplaceAll(new,
 						goMod.Upstream.Path,
 						newUpstream)
 				}


### PR DESCRIPTION
## Summary

Fixes #367

This PR fixes a bug in the major version bump logic where import path replacements were being discarded.

## The Bug

In `upgrade/steps.go` line 652, the second `strings.ReplaceAll` was using `data` instead of `new`:

```go
new := strings.ReplaceAll(data, /* ... provider version replacement ... */)

// Later...
new = strings.ReplaceAll(data,  // ← BUG: should be 'new'
    goMod.Upstream.Path,
    newUpstream)
```

This caused the first replacement to be **discarded**, leaving import paths like:
- `github.com/org/repo/provider/v3/pkg/version`

Unchanged during major version bumps (v3 → v4).

## The Fix

Changed line 652 to chain the replacements correctly:

```diff
-new = strings.ReplaceAll(data,
+new = strings.ReplaceAll(new,
```

Now both replacements apply sequentially:
1. First: provider version path (v3 → v4)
2. Second: upstream provider version (if applicable)

## Testing

This fix ensures all import paths in `provider/` are correctly updated during major version bumps, preventing build failures from stale module references.
