### PR TITLE
Fix: Chain string replacements in major version import updates

### DIFF
--- a/upgrade/steps.go
+++ b/upgrade/steps.go
@@ -649,7 +649,7 @@ var majorVersionBump = stepv2.Func30("Increment Major Version", func(
 					goMod.Upstream.Path); ok && major != "" {
 					newUpstream := fmt.Sprintf("%s/v%d",
 						prefix, target.Version.Major())
-					new = strings.ReplaceAll(data,
+					new = strings.ReplaceAll(new,
 						goMod.Upstream.Path,
 						newUpstream)
 				}


### PR DESCRIPTION
The second strings.ReplaceAll was using 'data' instead of 'new', causing the first replacement (provider version bump) to be discarded.

This fixes the bug where import paths like:
  github.com/org/repo/provider/v3/pkg/version
were not being updated to v4 during major version bumps.

Fixes #367