### PR TITLE
Close superseded bridge PRs after opening a new one

### DIFF
--- a/upgrade/steps.go
+++ b/upgrade/steps.go
@@ -1046,7 +1046,7 @@ var parseUpstreamProviderOrg = stepv2.Func11E("Get UpstreamOrg from module versi
 // authored by the current user, except the PR on keepBranch (the PR we just created or updated).
 // Each closed PR gets a comment pointing at newPrURL.
 //
-// Best-effort: a failure to close one PR must not abort the upgrade.
+// A failing gh call halts the upgrade, matching the style of other gh operations in this file.
 var closeSupersededBridgePRs = stepv2.Func30E("Close superseded bridge PRs", func(
 	ctx context.Context, repo, keepBranch, newPrURL string,
 ) error {
@@ -1066,7 +1066,19 @@ var closeSupersededBridgePRs = stepv2.Func30E("Close superseded bridge PRs", fun
 		return fmt.Errorf("parse gh pr list output: %w", err)
 	}
 
-	// Task 2 will add the close loop. For now, just return.
-	_ = prs
+	for _, pr := range prs {
+		if pr.HeadRefName == keepBranch {
+			continue
+		}
+		pr := pr
+		stepv2.Func10E(fmt.Sprintf("Close #%d", pr.Number), func(ctx context.Context, num string) error {
+			stepv2.Cmd(ctx, "gh",
+				"pr", "close", num,
+				"--repo", repo,
+				"--comment", "Superseded by "+newPrURL,
+			)
+			return nil
+		})(ctx, fmt.Sprintf("%d", pr.Number))
+	}
 	return nil
 })

--- a/upgrade/steps.go
+++ b/upgrade/steps.go
@@ -300,12 +300,19 @@ var InformGitHub = stepv2.Func60E("Inform Github", func(
 
 	prBody := prBody(ctx, repo, target, goMod, targetBridgeVersion, tfSDKUpgrade, osArgs)
 
+	var newPrURL string
 	if repo.prAlreadyExists {
 		// Update the description in case anything else was upgraded (or not
 		// upgraded) in this run, compared to the existing PR.
 		stepv2.Cmd(ctx, "gh", "pr", "edit", repo.workingBranch,
 			"--title", repo.prTitle,
 			"--body", prBody)
+		newPrURL = strings.TrimSpace(stepv2.Cmd(ctx, "gh",
+			"pr", "view", repo.workingBranch,
+			"--repo", fmt.Sprintf("%s/%s", repo.Org, repo.Name),
+			"--json", "url",
+			"--jq", ".url",
+		))
 	} else {
 		extraOptions := []string{}
 
@@ -328,7 +335,7 @@ var InformGitHub = stepv2.Func60E("Inform Github", func(
 			extraOptions = []string{"--label", "needs-release/patch"}
 		}
 
-		stepv2.Cmd(ctx, "gh",
+		newPrURL = strings.TrimSpace(stepv2.Cmd(ctx, "gh",
 			append([]string{
 				"pr", "create",
 				"--base", repo.defaultBranch,
@@ -337,7 +344,15 @@ var InformGitHub = stepv2.Func60E("Inform Github", func(
 				"--title", repo.prTitle,
 				"--body", prBody,
 			},
-				extraOptions...)...)
+				extraOptions...)...))
+	}
+
+	if c.UpgradeBridgeVersion && newPrURL != "" {
+		closeSupersededBridgePRs(ctx,
+			fmt.Sprintf("%s/%s", repo.Org, repo.Name),
+			repo.workingBranch,
+			newPrURL,
+		)
 	}
 
 	// If we are only upgrading the bridge, we won't have a list of issues.

--- a/upgrade/steps.go
+++ b/upgrade/steps.go
@@ -1041,3 +1041,32 @@ var parseUpstreamProviderOrg = stepv2.Func11E("Get UpstreamOrg from module versi
 	tok := strings.Split(modPathWithoutVersion(upstreamMod.Path), "/")
 	return tok[1], nil
 })
+
+// closeSupersededBridgePRs closes any open "Upgrade pulumi-terraform-bridge" PRs
+// authored by the current user, except the PR on keepBranch (the PR we just created or updated).
+// Each closed PR gets a comment pointing at newPrURL.
+//
+// Best-effort: a failure to close one PR must not abort the upgrade.
+var closeSupersededBridgePRs = stepv2.Func30E("Close superseded bridge PRs", func(
+	ctx context.Context, repo, keepBranch, newPrURL string,
+) error {
+	raw := stepv2.Cmd(ctx, "gh",
+		"pr", "list",
+		"--repo", repo,
+		"--state", "open",
+		"--search", `author:@me in:title "Upgrade pulumi-terraform-bridge"`,
+		"--json", "number,headRefName",
+	)
+
+	var prs []struct {
+		Number      int    `json:"number"`
+		HeadRefName string `json:"headRefName"`
+	}
+	if err := json.Unmarshal([]byte(raw), &prs); err != nil {
+		return fmt.Errorf("parse gh pr list output: %w", err)
+	}
+
+	// Task 2 will add the close loop. For now, just return.
+	_ = prs
+	return nil
+})

--- a/upgrade/steps.go
+++ b/upgrade/steps.go
@@ -347,20 +347,9 @@ var InformGitHub = stepv2.Func60E("Inform Github", func(
 				extraOptions...)...))
 	}
 
-	if c.UpgradeBridgeVersion && newPrURL != "" {
-		closeSupersededBridgePRs(ctx,
-			fmt.Sprintf("%s/%s", repo.Org, repo.Name),
-			repo.workingBranch,
-			newPrURL,
-		)
-	}
-
-	// If we are only upgrading the bridge, we won't have a list of issues.
-	if !c.UpgradeProviderVersion {
-		return nil
-	}
-
-	if c.PrAssign != "" {
+	// If we are only upgrading the bridge, we won't have a list of issues, so
+	// skip assignee plumbing in that case.
+	if c.UpgradeProviderVersion && c.PrAssign != "" {
 		stepv2.Func00("Assign Issues", func(ctx context.Context) {
 			// This PR will close issues, so we assign the issues same assignee as the
 			// PR itself.
@@ -369,6 +358,16 @@ var InformGitHub = stepv2.Func60E("Inform Github", func(
 					"--add-assignee", c.PrAssign)
 			}
 		})(ctx)
+	}
+
+	// Close superseded bridge PRs last so a failure here does not skip any
+	// earlier side effects (issue assignment, PR body update, etc.).
+	if c.UpgradeBridgeVersion && newPrURL != "" {
+		closeSupersededBridgePRs(ctx,
+			fmt.Sprintf("%s/%s", repo.Org, repo.Name),
+			repo.workingBranch,
+			newPrURL,
+		)
 	}
 
 	return nil

--- a/upgrade/steps_test.go
+++ b/upgrade/steps_test.go
@@ -525,3 +525,80 @@ func TestCloseSupersededBridgePRs_ListOnly(t *testing.T) {
 		},
 	}, "Close superseded bridge PRs", closeSupersededBridgePRs)
 }
+
+func TestCloseSupersededBridgePRs_Filters(t *testing.T) {
+	t.Parallel()
+
+	encode := func(elem any) json.RawMessage {
+		b, err := json.Marshal(elem)
+		require.NoError(t, err)
+		return json.RawMessage(b)
+	}
+
+	repo := "pulumi/pulumi-xyz"
+	keepBranch := "upgrade-pulumi-terraform-bridge-to-v3.99.0-ci"
+	newPrURL := "https://github.com/pulumi/pulumi-xyz/pull/42"
+
+	listJSON := `[
+		{"number": 10, "headRefName": "upgrade-pulumi-terraform-bridge-to-v3.97.0-ci"},
+		{"number": 11, "headRefName": "upgrade-pulumi-terraform-bridge-to-v3.99.0-ci"},
+		{"number": 12, "headRefName": "upgrade-pulumi-terraform-bridge-to-v3.98.0-ci"}
+	]`
+	comment := "Superseded by " + newPrURL
+
+	testReplay(context.Background(), t, []*step.Step{
+		{
+			Name:    "Close superseded bridge PRs",
+			Inputs:  encode([]string{repo, keepBranch, newPrURL}),
+			Outputs: encode([]any{nil}),
+		},
+		{
+			Name: "gh",
+			Inputs: encode([]any{
+				"gh", []string{
+					"pr", "list",
+					"--repo", repo,
+					"--state", "open",
+					"--search", `author:@me in:title "Upgrade pulumi-terraform-bridge"`,
+					"--json", "number,headRefName",
+				},
+			}),
+			Outputs: encode([]any{listJSON, nil}),
+			Impure:  true,
+		},
+		{
+			Name: "Close #10",
+			Inputs: encode([]string{"10"}),
+			Outputs: encode([]any{nil}),
+		},
+		{
+			Name: "gh",
+			Inputs: encode([]any{
+				"gh", []string{
+					"pr", "close", "10",
+					"--repo", repo,
+					"--comment", comment,
+				},
+			}),
+			Outputs: encode([]any{"", nil}),
+			Impure:  true,
+		},
+		{
+			Name: "Close #12",
+			Inputs: encode([]string{"12"}),
+			Outputs: encode([]any{nil}),
+		},
+		{
+			Name: "gh",
+			Inputs: encode([]any{
+				"gh", []string{
+					"pr", "close", "12",
+					"--repo", repo,
+					"--comment", comment,
+				},
+			}),
+			Outputs: encode([]any{"", nil}),
+			Impure:  true,
+		},
+	}, "Close superseded bridge PRs", closeSupersededBridgePRs)
+}

--- a/upgrade/steps_test.go
+++ b/upgrade/steps_test.go
@@ -490,7 +490,7 @@ func (sh simpleHttpHandler) getHTTP(url string) ([]byte, error) {
 	return sh(url)
 }
 
-func TestCloseSupersededBridgePRs_ListOnly(t *testing.T) {
+func TestCloseSupersededBridgePRs_EmptyList(t *testing.T) {
 	t.Parallel()
 
 	encode := func(elem any) json.RawMessage {

--- a/upgrade/steps_test.go
+++ b/upgrade/steps_test.go
@@ -489,3 +489,39 @@ var _ httpHandler = (*simpleHttpHandler)(nil)
 func (sh simpleHttpHandler) getHTTP(url string) ([]byte, error) {
 	return sh(url)
 }
+
+func TestCloseSupersededBridgePRs_ListOnly(t *testing.T) {
+	t.Parallel()
+
+	encode := func(elem any) json.RawMessage {
+		b, err := json.Marshal(elem)
+		require.NoError(t, err)
+		return json.RawMessage(b)
+	}
+
+	repo := "pulumi/pulumi-xyz"
+	keepBranch := "upgrade-pulumi-terraform-bridge-to-v3.99.0-ci"
+	newPrURL := "https://github.com/pulumi/pulumi-xyz/pull/42"
+
+	testReplay(context.Background(), t, []*step.Step{
+		{
+			Name:    "Close superseded bridge PRs",
+			Inputs:  encode([]string{repo, keepBranch, newPrURL}),
+			Outputs: encode([]any{nil}),
+		},
+		{
+			Name: "gh",
+			Inputs: encode([]any{
+				"gh", []string{
+					"pr", "list",
+					"--repo", repo,
+					"--state", "open",
+					"--search", `author:@me in:title "Upgrade pulumi-terraform-bridge"`,
+					"--json", "number,headRefName",
+				},
+			}),
+			Outputs: encode([]any{`[]`, nil}),
+			Impure:  true,
+		},
+	}, "Close superseded bridge PRs", closeSupersededBridgePRs)
+}

--- a/upgrade/testdata/replay/kong_existing_pr.json
+++ b/upgrade/testdata/replay/kong_existing_pr.json
@@ -109,8 +109,8 @@
           "inputs": [
             null,
             {
-              "Org": "",
-              "Name":"pulumi/pulumi-kong"
+              "Org": "pulumi",
+              "Name":"pulumi-kong"
             },
             {
               "Kind": "plain",
@@ -184,7 +184,7 @@
               "view",
               "upgrade-pulumi-terraform-bridge-to-v3.62.0",
               "--repo",
-              "/pulumi/pulumi-kong",
+              "pulumi/pulumi-kong",
               "--json",
               "url",
               "--jq",
@@ -200,7 +200,7 @@
         {
           "name": "Close superseded bridge PRs",
           "inputs": [
-            "/pulumi/pulumi-kong",
+            "pulumi/pulumi-kong",
             "upgrade-pulumi-terraform-bridge-to-v3.62.0",
             "https://github.com/pulumi/pulumi-kong/pull/228"
           ],
@@ -216,7 +216,7 @@
               "pr",
               "list",
               "--repo",
-              "/pulumi/pulumi-kong",
+              "pulumi/pulumi-kong",
               "--state",
               "open",
               "--search",

--- a/upgrade/testdata/replay/kong_existing_pr.json
+++ b/upgrade/testdata/replay/kong_existing_pr.json
@@ -174,6 +174,62 @@
             null
           ],
           "impure": true
+        },
+        {
+          "name": "gh",
+          "inputs": [
+            "gh",
+            [
+              "pr",
+              "view",
+              "upgrade-pulumi-terraform-bridge-to-v3.62.0",
+              "--repo",
+              "/pulumi/pulumi-kong",
+              "--json",
+              "url",
+              "--jq",
+              ".url"
+            ]
+          ],
+          "outputs": [
+            "https://github.com/pulumi/pulumi-kong/pull/228\n",
+            null
+          ],
+          "impure": true
+        },
+        {
+          "name": "Close superseded bridge PRs",
+          "inputs": [
+            "/pulumi/pulumi-kong",
+            "upgrade-pulumi-terraform-bridge-to-v3.62.0",
+            "https://github.com/pulumi/pulumi-kong/pull/228"
+          ],
+          "outputs": [
+            null
+          ]
+        },
+        {
+          "name": "gh",
+          "inputs": [
+            "gh",
+            [
+              "pr",
+              "list",
+              "--repo",
+              "/pulumi/pulumi-kong",
+              "--state",
+              "open",
+              "--search",
+              "author:@me in:title \"Upgrade pulumi-terraform-bridge\"",
+              "--json",
+              "number,headRefName"
+            ]
+          ],
+          "outputs": [
+            "[]",
+            null
+          ],
+          "impure": true
         }
       ]
     }

--- a/upgrade/upgrade_test.go
+++ b/upgrade/upgrade_test.go
@@ -71,7 +71,8 @@ func TestInformGithubExistingPR(t *testing.T) {
 				workingBranch:   "upgrade-pulumi-terraform-bridge-to-v3.62.0",
 				prTitle:         "Upgrade pulumi-terraform-bridge to v3.62.0",
 				defaultBranch:   "master",
-				Name:            "pulumi/pulumi-kong",
+				Org:             "pulumi",
+				Name:            "pulumi-kong",
 				prAlreadyExists: true,
 			}, &GoMod{
 				Kind: "plain",


### PR DESCRIPTION
## Summary

Extends the bridge-upgrade path so that after `InformGitHub` creates (or updates) the new `Upgrade pulumi-terraform-bridge to vX.Y.Z` PR, any earlier open bridge-upgrade PRs on the same repo are closed with a `Superseded by <new PR URL>` comment.

This addresses the acceptance criterion in pulumi/ci-mgmt#2121 (close existing upgrade bridge PRs that will be superseded by the current rollout). Puts the close logic in the Go CLI — the natural place, since the CLI already creates the PR and knows the new URL — so the action/workflow need no YAML-side changes once this ships.

### What changed

- New step function `closeSupersededBridgePRs` at the bottom of `upgrade/steps.go`.
  - Selection: `gh pr list --repo <r> --state open --search 'author:@me in:title "Upgrade pulumi-terraform-bridge"' --json number,headRefName`.
  - Excludes the PR on the working branch of the current run (we just pushed it).
  - Closes each remaining match with a `Superseded by <URL>` comment.
  - Halts on `gh` failure, matching the style of every other `gh pr …` call in this file (see "On best-effort" below).
- Wired into `InformGitHub`. Both the create and the edit branches now capture the new PR's URL into `newPrURL`; for the `prAlreadyExists` path this uses `gh pr view <branch> --repo <r> --json url --jq .url` since `gh pr edit` doesn't print the URL.
- Gate: `c.UpgradeBridgeVersion && newPrURL != ""` — only runs on bridge-upgrade paths.
- Placed as the final step in `InformGitHub` (after the "Assign Issues" block) so a halt here cannot skip earlier side effects.
- Cleaned up a pre-existing `ProviderRepo.Org`/`.Name` fixture oddity in `TestInformGithubExistingPR` so the replay doesn't assert a leading-slash `--repo` argument.

### On "best-effort"

An earlier draft planned to wrap each close in `defer recover()` so a single `gh pr close` failure wouldn't abort the upgrade. That approach doesn't work: `stepv2.Cmd` halts via `runtime.Goexit`, which is not caught by `recover`. The alternative — calling `exec.CommandContext` directly for each close — would bypass the step framework's test-replay harness and add a parallel exec path just for this one call site. Not worth the complexity. Accepted halt-on-failure instead, and placed this step last in `InformGitHub` so a failure has no downstream blast radius beyond the feature itself (the new PR is already created, any linked-issue assignees have already been set).

### Testing

- Three new tests in `upgrade/steps_test.go` using the existing `testReplay` harness:
  - `TestCloseSupersededBridgePRs_EmptyList` — list returns `[]`, no close calls.
  - `TestCloseSupersededBridgePRs_Filters` — three PRs, one matches the current branch and is skipped, the other two are closed.
- `TestInformGithubExistingPR` fixture extended (`upgrade/testdata/replay/kong_existing_pr.json`) to cover the new `gh pr view` and the `Close superseded bridge PRs` + inner `gh pr list` `[]` path.
- `go test ./...` passes; `go vet ./...` clean.

### Rollout

After this merges, `pulumi-upgrade-provider-action` picks up the new behavior automatically (its `go install github.com/pulumi/upgrade-provider@main` step pulls `main`). A companion ci-mgmt PR will bump the pinned `pulumi-upgrade-provider-action` SHA in `action-versions.yml` and regenerate test-provider workflows — that's what actually closes pulumi/ci-mgmt#2121.

## Test plan

- [x] `go test ./...` (via `mise exec go@1.24`) — all pass
- [x] `go vet ./...` — clean
- [ ] Post-merge: nightly bridge-upgrade rollout on a sample bridged provider (e.g. pulumi-aws) should close the most recently open `Upgrade pulumi-terraform-bridge …` PR once the new one opens.

🤖 Generated with [Claude Code](https://claude.com/claude-code)