### PR TITLE
Add allow-major provider upgrade flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ Usage:
 Flags:
       --allow-missing-docs              If true, don't error on missing docs during tfgen.
                                         This is equivalent to setting PULUMI_MISSING_DOCS_ERROR=${! VALUE}.
+      --allow-major                     Allow the provider to upgrade to a new major version when one is available.
   -h, --help                            help for upgrade-provider
       --java-version string             The version of pulumi-java-gen to target.
       --kind strings                    The kind of upgrade to perform:
@@ -201,6 +202,8 @@ A configuration file `.upgrade-config.{yml/json}` may be defined within the prov
 Values include:
 
 - `upstream-provider-name`: The name of the upstream provider repo, i.e. `terraform-provider-docker`
+- `allow-major`: Allow provider upgrades to proceed through the major-version upgrade path when the target upstream
+  version crosses a major version boundary.
 - `pr-reviewers`: A comma separated list of reviewers to assign the upgrade PR to.
 - `pr-assign`: A user to assign the upgrade PR to (default: `@me`).
 

--- a/main.go
+++ b/main.go
@@ -185,6 +185,9 @@ we take '--target-version' to cap the inferred version. [Hidden behind PULUMI_DE
 	cmd.PersistentFlags().BoolVar(&context.MajorVersionBump, "major", false,
 		`Upgrade the provider to a new major version.`)
 
+	cmd.PersistentFlags().BoolVar(&context.AllowMajorVersionBump, "allow-major", false,
+		`Allow the provider to upgrade to a new major version when one is available.`)
+
 	kindMsg := `The kind of upgrade to perform:
 
 - "all": Upgrade the upstream provider and the bridge. Shorthand for "bridge,provider".
@@ -281,12 +284,16 @@ func initializeConfig(cmd *cobra.Command) error {
 
 // Bind each cobra flag to its associated viper configuration (config file and environment variable)
 func bindFlags(cmd *cobra.Command, v *viper.Viper) {
-	cmd.Flags().VisitAll(func(f *pflag.Flag) {
-		// Apply the viper config value to the flag when the flag is not set and viper has a value
-		if !f.Changed && v.IsSet(f.Name) {
-			val := v.Get(f.Name)
-			err := cmd.Flags().Set(f.Name, fmt.Sprintf("%v", val))
-			contract.AssertNoErrorf(err, "error setting flag")
-		}
-	})
+	bindFlagSet := func(flags *pflag.FlagSet) {
+		flags.VisitAll(func(f *pflag.Flag) {
+			// Apply the viper config value to the flag when the flag is not set and viper has a value
+			if !f.Changed && v.IsSet(f.Name) {
+				val := v.Get(f.Name)
+				err := flags.Set(f.Name, fmt.Sprintf("%v", val))
+				contract.AssertNoErrorf(err, "error setting flag")
+			}
+		})
+	}
+	bindFlagSet(cmd.Flags())
+	bindFlagSet(cmd.PersistentFlags())
 }

--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,28 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestInitializeConfigBindsAllowMajor(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, ".upgrade-config.yml"), []byte("allow-major: true\n"), 0o600))
+
+	previous, err := os.Getwd()
+	require.NoError(t, err)
+	require.NoError(t, os.Chdir(dir))
+	t.Cleanup(func() {
+		require.NoError(t, os.Chdir(previous))
+	})
+
+	command := cmd()
+	require.NoError(t, initializeConfig(command))
+
+	flag := command.PersistentFlags().Lookup("allow-major")
+	require.NotNil(t, flag)
+	require.Equal(t, "true", flag.Value.String())
+}

--- a/upgrade/upgrade_provider.go
+++ b/upgrade/upgrade_provider.go
@@ -22,6 +22,34 @@ func setEnv(ctx context.Context, k, v string) {
 	})(ctx, k, v)
 }
 
+func applyMajorVersionPolicy(ctx context.Context, repo *ProviderRepo, upgradeTarget *UpstreamUpgradeTarget) error {
+	c := GetContext(ctx)
+	if !c.UpgradeProviderVersion || upgradeTarget == nil || upgradeTarget.Version == nil {
+		return nil
+	}
+	if repo.currentUpstreamVersion == nil {
+		return fmt.Errorf("could not determine current upstream version; cannot determine whether %s is a major version update",
+			upgradeTarget.Version)
+	}
+
+	shouldMajorVersionBump := repo.currentUpstreamVersion.Major() != upgradeTarget.Version.Major()
+	if c.MajorVersionBump && !shouldMajorVersionBump {
+		return fmt.Errorf("--major version update indicated, but no major upgrade available (already on v%d)",
+			repo.currentUpstreamVersion.Major())
+	}
+	if shouldMajorVersionBump {
+		if c.AllowMajorVersionBump {
+			c.MajorVersionBump = true
+			return nil
+		}
+		if !c.MajorVersionBump {
+			return fmt.Errorf("this is a major version update (v%d -> v%d), but neither --major nor --allow-major was passed",
+				repo.currentUpstreamVersion.Major(), upgradeTarget.Version.Major())
+		}
+	}
+	return nil
+}
+
 func UpgradeProvider(ctx context.Context, repoOrg, repoName string) (err error) {
 	// Setup ctx to enable replay tests with stepv2:
 	if file := os.Getenv("PULUMI_REPLAY"); file != "" {
@@ -107,23 +135,17 @@ func UpgradeProvider(ctx context.Context, repoOrg, repoName string) (err error) 
 			GetContext(ctx).MaintenancePatch = maintenanceRelease(ctx, repo)
 		}
 
+		if GetContext(ctx).UpgradeProviderVersion {
+			err := applyMajorVersionPolicy(ctx, &repo, upgradeTarget)
+			stepv2.HaltOnError(ctx, err)
+		}
+
 		if GetContext(ctx).MajorVersionBump {
 			repo.currentVersion = findCurrentMajorVersion(ctx, repoOrg, repoName)
 		}
 	})
 	if err != nil {
 		return err
-	}
-
-	if GetContext(ctx).UpgradeProviderVersion {
-		shouldMajorVersionBump := repo.currentUpstreamVersion.Major() != upgradeTarget.Version.Major()
-		if GetContext(ctx).MajorVersionBump && !shouldMajorVersionBump {
-			return fmt.Errorf("--major version update indicated, but no major upgrade available (already on v%d)",
-				repo.currentUpstreamVersion.Major())
-		} else if !GetContext(ctx).MajorVersionBump && shouldMajorVersionBump {
-			return fmt.Errorf("this is a major version update (v%d -> v%d), but --major was not passed",
-				repo.currentUpstreamVersion.Major(), upgradeTarget.Version.Major())
-		}
 	}
 
 	// Running the discover steps might have invalidated one or more actions. If there

--- a/upgrade/upgrade_test.go
+++ b/upgrade/upgrade_test.go
@@ -111,6 +111,107 @@ func TestBridgeUpgradeNoop(t *testing.T) {
 	assert.False(t, GetContext(ctx).UpgradeBridgeVersion)
 }
 
+func TestApplyMajorVersionPolicy(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		current     string
+		target      string
+		major       bool
+		allowMajor  bool
+		unknown     bool
+		expectMajor bool
+		expectErr   string
+	}{
+		{
+			name:        "minor upgrade without flags proceeds normally",
+			current:     "1.1.0",
+			target:      "1.2.0",
+			expectMajor: false,
+		},
+		{
+			name:        "minor upgrade with allow-major proceeds normally",
+			current:     "1.1.0",
+			target:      "1.2.0",
+			allowMajor:  true,
+			expectMajor: false,
+		},
+		{
+			name:        "minor upgrade with major assertion errors",
+			current:     "1.1.0",
+			target:      "1.2.0",
+			major:       true,
+			expectMajor: true,
+			expectErr:   "--major version update indicated, but no major upgrade available (already on v1)",
+		},
+		{
+			name:        "major upgrade without flags errors",
+			current:     "1.1.0",
+			target:      "2.0.0",
+			expectMajor: false,
+			expectErr:   "this is a major version update (v1 -> v2), but neither --major nor --allow-major was passed",
+		},
+		{
+			name:        "major upgrade with allow-major enables major bump",
+			current:     "1.1.0",
+			target:      "2.0.0",
+			allowMajor:  true,
+			expectMajor: true,
+		},
+		{
+			name:        "major upgrade with major assertion proceeds",
+			current:     "1.1.0",
+			target:      "2.0.0",
+			major:       true,
+			expectMajor: true,
+		},
+		{
+			name:        "major upgrade with both flags proceeds",
+			current:     "1.1.0",
+			target:      "2.0.0",
+			major:       true,
+			allowMajor:  true,
+			expectMajor: true,
+		},
+		{
+			name:      "unknown current upstream version errors",
+			target:    "2.0.0",
+			unknown:   true,
+			expectErr: "could not determine current upstream version; cannot determine whether 2.0.0 is a major version update",
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			c := &Context{
+				UpgradeProviderVersion: true,
+				MajorVersionBump:       tt.major,
+				AllowMajorVersionBump:  tt.allowMajor,
+			}
+			ctx := c.Wrap(context.Background())
+			repo := ProviderRepo{}
+			if !tt.unknown {
+				repo.currentUpstreamVersion = semver.MustParse(tt.current)
+			}
+			target := &UpstreamUpgradeTarget{
+				Version: semver.MustParse(tt.target),
+			}
+
+			err := applyMajorVersionPolicy(ctx, &repo, target)
+			if tt.expectErr != "" {
+				require.EqualError(t, err, tt.expectErr)
+			} else {
+				require.NoError(t, err)
+			}
+			assert.Equal(t, tt.expectMajor, c.MajorVersionBump)
+		})
+	}
+}
+
 func newReplay(t *testing.T, name string) context.Context {
 	t.Helper()
 	ctx := context.Background()

--- a/upgrade/util.go
+++ b/upgrade/util.go
@@ -36,6 +36,7 @@ type Context struct {
 
 	UpgradeProviderVersion bool
 	MajorVersionBump       bool
+	AllowMajorVersionBump  bool
 
 	// Some providers go for months without an upstream release, but do receive weekly bridge updates.
 	// upgrade-provider will detect if the provider's last release is more than eight weeks old, and if it is,


### PR DESCRIPTION
## Summary
- add an `--allow-major` flag for automation that permits major provider upgrades only when the planned target actually crosses a major boundary
- keep `--major` as a strict assertion that errors on non-major upgrades
- document `allow-major` in provider config and cover config binding plus major policy behavior in tests

## Motivation

We want the ability to opt-in certain providers to major version upgrades. https://github.com/pulumi/pulumi-fastly/pull/1009 is an example of where this would be useful. Providers will now be able to opt-in to this ability by updating `.upgrade-config.yml` to include `allow-major: true`.

re https://github.com/pulumi/home/issues/4562

## Testing
- `go test ./...`