### PR TITLE
Drop legacy pulumi-java/pkg require during bridge upgrade

### DIFF
--- a/upgrade/upgrade_provider.go
+++ b/upgrade/upgrade_provider.go
@@ -228,6 +228,15 @@ func UpgradeProvider(ctx context.Context, repoOrg, repoName string) (err error) 
 				"github.com/pulumi/pulumi-terraform-bridge/v3@"+targetBridgeVersion.String()),
 			step.Cmd("go", "get", "github.com/hashicorp/terraform-plugin-framework"),
 			step.Cmd("go", "get", "github.com/hashicorp/terraform-plugin-mux"),
+			// pulumi-java was renamed from pulumi-java/pkg to pulumi-java in
+			// pulumi-java#2121. The legacy module's last release (v1.22.0) is
+			// incompatible with pulumi/pulumi v3.232.0+. Go resolves the import
+			// path github.com/pulumi/pulumi-java/pkg/codegen/java to whichever
+			// module has the longest matching prefix, so as long as a stale
+			// `pulumi-java/pkg` require remains, it shadows the new module.
+			// No-op once the require is gone.
+			step.Cmd("go", "mod", "edit",
+				"-droprequire", "github.com/pulumi/pulumi-java/pkg"),
 			step.Cmd("go", "mod", "tidy"),
 		).In(repo.providerDir()))
 	}


### PR DESCRIPTION
## Summary

Adds a `go mod edit -droprequire github.com/pulumi/pulumi-java/pkg` step to the bridge-upgrade flow, immediately before the existing `go mod tidy`.

## Why

`pulumi-java` was renamed from a sub-module (`github.com/pulumi/pulumi-java/pkg`) to a root module (`github.com/pulumi/pulumi-java`) in pulumi-java#2121, first released as v1.23.0. The legacy module's last release is v1.22.0, which still references PCL APIs (`Resource.DecomposeToken`, `Resource.Token`, `pcl.FixupPulumiPackageTokens`) that `pulumi/pulumi` removed in v3.232.0.

Tracking issue: pulumi/home#4693.

## How

`go mod edit -droprequire` is a no-op when the require is absent, so this is:
- self-healing for providers that haven't yet been migrated off `pulumi-java/pkg`,
- a no-op for providers that already migrated.

Verified locally against pulumi-aiven: with the droprequire applied, `go mod tidy` flips the resolver from `pulumi-java/pkg@v1.21.3` (broken) to `pulumi-java@v1.25.1-0.20260430213031-...` (fixed), and `make schema` builds.

## Test plan

- [ ] CI green on this branch
- [x] Manually run bridge upgrade against a provider known to be on the legacy `pulumi-java/pkg` (e.g. pulumi-aiven, pulumi-aws) and confirm the upgrade PR builds : https://github.com/pulumi/pulumi-aiven/pull/1162

🤖 Generated with [Claude Code](https://claude.com/claude-code)