### PR TITLE
Fix mise env refresh after provider updates

### DIFF
--- a/upgrade/mise_test.go
+++ b/upgrade/mise_test.go
@@ -1,0 +1,83 @@
+package upgrade
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	stepv2 "github.com/pulumi/upgrade-provider/step/v2"
+)
+
+func TestRunMiseUpgradeRefreshesFromUpdatedProviderGoMod(t *testing.T) {
+	t.Setenv("PULUMI_VERSION_MISE", "3.228.0")
+	t.Setenv("GO_VERSION_MISE", "1.25.8")
+
+	tempDir := t.TempDir()
+	binDir := filepath.Join(tempDir, "bin")
+	require.NoError(t, os.MkdirAll(binDir, 0o755))
+	logPath := filepath.Join(tempDir, "mise.log")
+	t.Setenv("MISE_TEST_LOG", logPath)
+
+	misePath := filepath.Join(binDir, "mise")
+	require.NoError(t, os.WriteFile(misePath, []byte(`#!/usr/bin/env bash
+set -euo pipefail
+
+case "${1:-}" in
+upgrade)
+	echo "upgrade PULUMI_VERSION_MISE=${PULUMI_VERSION_MISE:-} GO_VERSION_MISE=${GO_VERSION_MISE:-}" >> "${MISE_TEST_LOG}"
+	;;
+env)
+	echo "env PULUMI_VERSION_MISE=${PULUMI_VERSION_MISE:-} GO_VERSION_MISE=${GO_VERSION_MISE:-}" >> "${MISE_TEST_LOG}"
+	printf '{"PULUMI_VERSION_MISE":"%s","GO_VERSION_MISE":"%s"}\n' "${PULUMI_VERSION_MISE:-}" "${GO_VERSION_MISE:-}"
+	;;
+*)
+	echo "unexpected mise command: $*" >&2
+	exit 2
+	;;
+esac
+`), 0o755))
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	repoRoot := filepath.Join(tempDir, "repo")
+	require.NoError(t, os.MkdirAll(filepath.Join(repoRoot, "provider"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(repoRoot, "provider", "go.mod"), []byte(`module example.com/provider
+
+go 1.25.9
+
+require github.com/pulumi/pulumi/sdk/v3 v3.234.0
+`), 0o600))
+
+	err := stepv2.PipelineCtx(context.Background(), "test mise refresh", func(ctx context.Context) {
+		repo := ProviderRepo{root: repoRoot}
+		env := []stepv2.Env{&stepv2.SetCwd{To: repo.root}}
+		ctx = stepv2.WithEnv(ctx, env...)
+		miseEnvVars := map[string]*stepv2.EnvVar{}
+
+		var ok bool
+		ctx, ok = runMiseUpgrade(ctx, repo, &env, miseEnvVars)
+		if !ok {
+			stepv2.HaltOnError(ctx, errors.New("mise not available"))
+		}
+		ctx = refreshMiseEnv(ctx, &env, miseEnvVars)
+
+		stepv2.Cmd(ctx, "bash", "-c", fmt.Sprintf(
+			"echo downstream PULUMI_VERSION_MISE=${PULUMI_VERSION_MISE:-} GO_VERSION_MISE=${GO_VERSION_MISE:-} >> %q",
+			logPath))
+	}, stepv2.NullDisplay)
+	require.NoError(t, err)
+
+	log, err := os.ReadFile(logPath)
+	require.NoError(t, err)
+	require.Equal(t, strings.Join([]string{
+		"upgrade PULUMI_VERSION_MISE=3.234.0 GO_VERSION_MISE=1.25.9",
+		"env PULUMI_VERSION_MISE=3.234.0 GO_VERSION_MISE=1.25.9",
+		"downstream PULUMI_VERSION_MISE=3.234.0 GO_VERSION_MISE=1.25.9",
+		"",
+	}, "\n"), string(log))
+}

--- a/upgrade/upgrade_provider.go
+++ b/upgrade/upgrade_provider.go
@@ -291,7 +291,8 @@ func tfgenAndBuildSDKs(
 
 		miseEnvVars := map[string]*stepv2.EnvVar{}
 
-		miseAvailable := runMiseUpgrade(ctx, repo)
+		miseAvailable := false
+		ctx, miseAvailable = runMiseUpgrade(ctx, repo, &env, miseEnvVars)
 		if miseAvailable {
 			ctx = refreshMiseEnv(ctx, &env, miseEnvVars)
 		}
@@ -309,7 +310,8 @@ func tfgenAndBuildSDKs(
 		})
 
 		if miseAvailable {
-			if runMiseUpgrade(ctx, repo) {
+			if updatedCtx, ok := runMiseUpgrade(ctx, repo, &env, miseEnvVars); ok {
+				ctx = updatedCtx
 				ctx = refreshMiseEnv(ctx, &env, miseEnvVars)
 			}
 		}
@@ -351,10 +353,12 @@ func tfgenAndBuildSDKs(
 	}
 }
 
-func runMiseUpgrade(ctx context.Context, repo ProviderRepo) bool {
+func runMiseUpgrade(
+	ctx context.Context, repo ProviderRepo, env *[]stepv2.Env, current map[string]*stepv2.EnvVar,
+) (context.Context, bool) {
 	if _, err := exec.LookPath("mise"); err != nil {
 		stepv2.SetLabel(ctx, "mise not found; skipping upgrade")
-		return false
+		return ctx, false
 	}
 
 	pulumiVersion, err := pulumiVersionFromProvider(repo)
@@ -364,15 +368,27 @@ func runMiseUpgrade(ctx context.Context, repo ProviderRepo) bool {
 
 	version := strings.TrimPrefix(pulumiVersion, "v")
 
-	miseCtx := stepv2.WithEnv(ctx,
-		&stepv2.EnvVar{Key: "PULUMI_VERSION_MISE", Value: version},
-		&stepv2.EnvVar{Key: "GO_VERSION_MISE", Value: goVersion},
-		&stepv2.EnvVar{Key: "MISE_TRUSTED_CONFIG_PATHS", Value: repo.root},
-		&stepv2.EnvVar{Key: "MISE_YES", Value: "1"},
-	)
+	ctx = setMiseEnv(ctx, env, current, "PULUMI_VERSION_MISE", version)
+	ctx = setMiseEnv(ctx, env, current, "GO_VERSION_MISE", goVersion)
+	ctx = setMiseEnv(ctx, env, current, "MISE_TRUSTED_CONFIG_PATHS", repo.root)
+	ctx = setMiseEnv(ctx, env, current, "MISE_YES", "1")
 
-	stepv2.Cmd(miseCtx, "mise", "upgrade", "--raw")
-	return true
+	stepv2.Cmd(ctx, "mise", "upgrade", "--raw")
+	return ctx, true
+}
+
+func setMiseEnv(
+	ctx context.Context, env *[]stepv2.Env, current map[string]*stepv2.EnvVar, key, value string,
+) context.Context {
+	if existing, ok := current[key]; ok {
+		existing.Value = value
+		return ctx
+	}
+
+	envVar := &stepv2.EnvVar{Key: key, Value: value}
+	current[key] = envVar
+	*env = append(*env, envVar)
+	return stepv2.WithEnv(ctx, envVar)
 }
 
 func refreshMiseEnv(ctx context.Context, env *[]stepv2.Env, current map[string]*stepv2.EnvVar) context.Context {


### PR DESCRIPTION
## Summary
- persist the Pulumi and Go mise env vars read from the upgraded provider go.mod into the shared step context
- run `mise env --json` and downstream generation commands under those refreshed vars instead of stale job-level values
- add a regression test that starts with stale mise vars and verifies `mise upgrade`, `mise env`, and a downstream command all see the upgraded versions

## Test
- `go test ./...`