### PR TITLE
cli: Display version (and commit) that was used for building

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,14 +1,18 @@
+VERSION := $(shell git describe --tags --abbrev=0 2>/dev/null || echo "v0.0.0")
+COMMIT := $(shell git rev-parse --short=8 HEAD 2>/dev/null || echo "unknown")
+LDFLAGS := -X main.version=$(VERSION) -X main.commit=$(COMMIT)
+
 bin:
 	mkdir -p bin
 
 build: tidy bin
-	go build -o ./bin/upgrade-provider github.com/pulumi/upgrade-provider
+	go build -ldflags "$(LDFLAGS)" -o ./bin/upgrade-provider github.com/pulumi/upgrade-provider
 
 tidy:
 	go mod tidy
 
 install:
-	go install github.com/pulumi/upgrade-provider
+	go install -ldflags "$(LDFLAGS)" github.com/pulumi/upgrade-provider
 
 lint:
 	golangci-lint run

--- a/README.md
+++ b/README.md
@@ -42,6 +42,13 @@ go install github.com/pulumi/upgrade-provider@main
 Additionally, `upgrade-provider` relies on all tools necessary for a manual provider upgrade.
 That generally means `pulumi`, `make`, and the build toolchain for each released SDK.
 
+## Version
+
+`upgrade-provider --version` prints the version (and, when available, the commit) that the
+binary was built from. The same information is shown at the top of `upgrade-provider --help`.
+Binaries built with `make build`/`make install` embed the version from `git describe` and the
+current commit hash via `-ldflags`.
+
 ## Usage
 
 ### From the command line

--- a/main.go
+++ b/main.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"go/build"
 	"os"
+	"runtime/debug"
 	"strconv"
 	"strings"
 
@@ -27,6 +28,54 @@ const (
 	// For example, --number is bound to UPGRADE_NUMBER.
 	envPrefix = "UPGRADE"
 )
+
+// version and commit are set via `-ldflags` at build time, e.g.:
+//
+//	go build -ldflags "-X main.version=v1.2.3 -X main.commit=abc1234"
+//
+// When they are not set (as with `go build`/`go run` without ldflags), we fall
+// back to the module version and VCS revision embedded by the Go toolchain via
+// `runtime/debug.ReadBuildInfo`, which covers `go install` from a tagged/pseudo
+// version.
+var (
+	version = ""
+	commit  = ""
+)
+
+// buildVersion returns a human readable version string of the form
+// "<version>-<commit>", falling back to information embedded by the Go
+// toolchain when ldflags were not supplied at build time.
+func buildVersion() string {
+	v, c := version, commit
+
+	if v == "" || c == "" {
+		if info, ok := debug.ReadBuildInfo(); ok {
+			if v == "" && info.Main.Version != "" && info.Main.Version != "(devel)" {
+				v = info.Main.Version
+			}
+			for _, s := range info.Settings {
+				if s.Key == "vcs.revision" && c == "" {
+					c = s.Value
+				}
+			}
+		}
+	}
+
+	if len(c) > 8 {
+		c = c[:8]
+	}
+
+	switch {
+	case v == "" && c == "":
+		return "unknown"
+	case v == "":
+		return c
+	case c == "":
+		return v
+	default:
+		return fmt.Sprintf("%s-%s", v, c)
+	}
+}
 
 func cmd() *cobra.Command {
 	var targetVersion string
@@ -61,7 +110,11 @@ func cmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "upgrade-provider <provider>",
 		Short: "upgrade-provider automates the process of upgrading a TF-bridged provider",
-		Args:  cobra.ExactArgs(1),
+		Long: fmt.Sprintf(
+			"upgrade-provider automates the process of upgrading a TF-bridged provider\n\nVersion: %s",
+			buildVersion()),
+		Version: buildVersion(),
+		Args:    cobra.ExactArgs(1),
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
 			err := initializeConfig(cmd)
 			if err != nil {
@@ -229,6 +282,10 @@ This is equivalent to setting PULUMI_MISSING_DOCS_ERROR=${! VALUE}.`)
 
 	cmd.PersistentFlags().BoolVar(&context.DryRun, "dry-run", false,
 		`If true, don't actually create any PRs`)
+
+	// Print just the version string for `--version`/`-v`, matching the format
+	// shown in `--help` (e.g. "v0.0.1-3212adb3").
+	cmd.SetVersionTemplate("{{.Version}}\n")
 
 	return cmd
 }

--- a/main_test.go
+++ b/main_test.go
@@ -26,3 +26,32 @@ func TestInitializeConfigBindsAllowMajor(t *testing.T) {
 	require.NotNil(t, flag)
 	require.Equal(t, "true", flag.Value.String())
 }
+
+func TestBuildVersion(t *testing.T) {
+	originalVersion, originalCommit := version, commit
+	t.Cleanup(func() {
+		version, commit = originalVersion, originalCommit
+	})
+
+	t.Run("version and commit set via ldflags", func(t *testing.T) {
+		version, commit = "v1.2.3", "3212adb3abcd"
+		require.Equal(t, "v1.2.3-3212adb3", buildVersion())
+	})
+
+	t.Run("only version set", func(t *testing.T) {
+		version, commit = "v1.2.3", ""
+		require.Equal(t, "v1.2.3", buildVersion())
+	})
+}
+
+func TestCmdReportsVersion(t *testing.T) {
+	originalVersion, originalCommit := version, commit
+	version, commit = "v1.2.3", "3212adb3"
+	t.Cleanup(func() {
+		version, commit = originalVersion, originalCommit
+	})
+
+	command := cmd()
+	require.Equal(t, "v1.2.3-3212adb3", command.Version)
+	require.Contains(t, command.Long, "Version: v1.2.3-3212adb3")
+}


### PR DESCRIPTION
## Summary

Closes #376.

- `upgrade-provider --help` now shows the build version at the top of the help text:
  ```
  upgrade-provider automates the process of upgrading a TF-bridged provider

  Version: v0.0.1-b52136e0

  Usage:
    upgrade-provider <provider> [flags]
  ...
  ```
- `upgrade-provider --version` (or `-v`) now prints just the version string, e.g. `v0.0.1-b52136e0`.

## How the version is determined

- `main.go` adds `version`/`commit` package-level variables that can be injected at build time via `-ldflags "-X main.version=... -X main.commit=..."`.
- `make build` and `make install` now set these ldflags automatically using `git describe --tags --abbrev=0` for the version and `git rev-parse --short=8 HEAD` for the commit.
- When ldflags aren't provided (e.g. plain `go build`/`go run`, or `go install github.com/pulumi/upgrade-provider@<ref>`), `buildVersion()` falls back to the module version and VCS revision embedded automatically by the Go toolchain (`runtime/debug.ReadBuildInfo`), so the flag still reports something useful (e.g. the commit hash) instead of nothing.

## Testing

- Added `TestBuildVersion` and `TestCmdReportsVersion` unit tests covering the ldflags-driven version string and its propagation into the cobra command.
- Ran `go build`, `go test ./...`, and `golangci-lint run` (matching CI's `v1.61.0`) — all pass.
- Manually verified `make build` output for both `--help` and `--version`/`-v`.


---
*Created with [Eon](https://eon.corp.pulumi.com/session/a28e064574b5859f19d1250ffa7e327f)*