### PR TITLE
Print link to created/updated PR after upgrade

### DIFF
--- a/upgrade/steps.go
+++ b/upgrade/steps.go
@@ -277,17 +277,17 @@ var maintenanceRelease = stepv2.Func11E("Check if we should release a maintenanc
 	return false, nil
 })
 
-var InformGitHub = stepv2.Func60E("Inform Github", func(
+var InformGitHub = stepv2.Func61E("Inform Github", func(
 	ctx context.Context, target *UpstreamUpgradeTarget, repo ProviderRepo,
 	goMod *GoMod, targetBridgeVersion Ref, tfSDKUpgrade string,
 	osArgs []string,
-) error {
+) (string, error) {
 	ctx = stepv2.WithEnv(ctx, &stepv2.SetCwd{To: repo.root})
 	c := GetContext(ctx)
 
 	if c.DryRun {
 		stepv2.SetLabel(ctx, "Dry run: skipping git push and PR creation")
-		return nil
+		return "", nil
 	}
 
 	// --force:
@@ -370,7 +370,7 @@ var InformGitHub = stepv2.Func60E("Inform Github", func(
 		)
 	}
 
-	return nil
+	return newPrURL, nil
 })
 
 var upgradeLabel = stepv2.Func21("Release Label", func(ctx context.Context, from, to *semver.Version) string {

--- a/upgrade/testdata/replay/kong_existing_pr.json
+++ b/upgrade/testdata/replay/kong_existing_pr.json
@@ -134,6 +134,7 @@
             ]
           ],
           "outputs": [
+            "https://github.com/pulumi/pulumi-kong/pull/228",
             null
           ]
         },

--- a/upgrade/testdata/replay/wavefront_inform_github.json
+++ b/upgrade/testdata/replay/wavefront_inform_github.json
@@ -37,6 +37,7 @@
             ]
           ],
           "outputs": [
+            "https://github.com/pulumi/pulumi-wavefront/pull/239",
             null
           ]
         },

--- a/upgrade/upgrade_provider.go
+++ b/upgrade/upgrade_provider.go
@@ -276,14 +276,24 @@ func UpgradeProvider(ctx context.Context, repoOrg, repoName string) (err error) 
 		return ErrHandled
 	}
 
-	return stepv2.PipelineCtx(ctx, "Tfgen & Build SDKs",
+	var newPrURL string
+	err = stepv2.PipelineCtx(ctx, "Tfgen & Build SDKs",
 		tfgenAndBuildSDKs(repo, repoName, upgradeTarget, goMod,
-			targetBridgeVersion, tfSDKUpgrade))
+			targetBridgeVersion, tfSDKUpgrade, &newPrURL))
+	if err != nil {
+		return err
+	}
+
+	if newPrURL != "" {
+		fmt.Printf("Link to PR created: %s\n", newPrURL)
+	}
+
+	return nil
 }
 
 func tfgenAndBuildSDKs(
 	repo ProviderRepo, repoName string, upgradeTarget *UpstreamUpgradeTarget, goMod *GoMod,
-	targetBridgeVersion Ref, tfSDKUpgrade string,
+	targetBridgeVersion Ref, tfSDKUpgrade string, newPrURL *string,
 ) func(ctx context.Context) {
 	return func(ctx context.Context) {
 		env := []stepv2.Env{&stepv2.SetCwd{To: repo.root}}
@@ -349,7 +359,7 @@ func tfgenAndBuildSDKs(
 
 		gitCommit(ctx, fmt.Sprintf("make %s", gen))
 
-		InformGitHub(ctx, upgradeTarget, repo, goMod, targetBridgeVersion, tfSDKUpgrade, os.Args)
+		*newPrURL = InformGitHub(ctx, upgradeTarget, repo, goMod, targetBridgeVersion, tfSDKUpgrade, os.Args)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Closes #378
- `InformGitHub` now returns the PR URL it created (or the existing PR URL it updated), instead of just an `error`.
- `UpgradeProvider` prints `Link to PR created: <url>` once the "Tfgen & Build SDKs" pipeline completes successfully, so the URL isn't buried in the raw `gh pr create` output.
- No output is printed for dry runs or when no PR URL is available.

## Example

```
...
Link to PR created: https://github.com/pulumi/pulumi-gcp/pull/3854
```

## Testing
- Updated the two replay fixtures (`wavefront_inform_github.json`, `kong_existing_pr.json`) that assert on `InformGitHub`'s outputs to include the returned PR URL.
- `go build ./...`
- `go vet ./...`
- `go test ./...` (all passing)


---
*Created with [Eon](https://eon.corp.pulumi.com/session/3a9edf95841a76d66ad3625205d86daa)*