### PR TITLE
Propagate Git identity to patched provider upgrades

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,20 @@ go install github.com/pulumi/upgrade-provider@main
 Additionally, `upgrade-provider` relies on all tools necessary for a manual provider upgrade.
 That generally means `pulumi`, `make`, and the build toolchain for each released SDK.
 
+Global Git configuration is not required for patched-provider upgrades. Immediately
+before running the `scripts/upstream.sh` patch workflow, `upgrade-provider` resolves
+the Git author and committer identity from, in order:
+
+1. Non-empty `GIT_AUTHOR_NAME`, `GIT_AUTHOR_EMAIL`, `GIT_COMMITTER_NAME`, and
+   `GIT_COMMITTER_EMAIL` environment variables. Partial environment identity is
+   completed from the following sources without replacing its non-empty values.
+2. The effective `user.name` and `user.email` configuration of the provider repository.
+
+The resolved identity is passed to the patch workflow and subsequent Git commands
+without writing global configuration. If no identity can be resolved, the tool stops
+before `scripts/upstream.sh` runs and explains how to set the standard Git environment
+variables or repository-local configuration.
+
 ## Version
 
 `upgrade-provider --version` prints the version (and, when available, the commit) that the

--- a/README.md
+++ b/README.md
@@ -49,7 +49,11 @@ the Git author and committer identity from, in order:
 1. Non-empty `GIT_AUTHOR_NAME`, `GIT_AUTHOR_EMAIL`, `GIT_COMMITTER_NAME`, and
    `GIT_COMMITTER_EMAIL` environment variables. Partial environment identity is
    completed from the following sources without replacing its non-empty values.
-2. The effective `user.name` and `user.email` configuration of the provider repository.
+2. The effective `author.name`/`author.email` and `committer.name`/`committer.email`
+   configuration of the provider repository, applied to the author and committer
+   identities respectively.
+3. The effective `user.name` and `user.email` configuration of the provider repository,
+   for any author or committer fields still missing.
 
 The resolved identity is passed to the patch workflow and subsequent Git commands
 without writing global configuration. If no identity can be resolved, the tool stops

--- a/step/step.go
+++ b/step/step.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"sort"
 	"strings"
 	"time"
 
@@ -32,6 +33,50 @@ type step struct {
 	f           func(context.Context) (string, error)
 	path        *string
 	rvalue      *string
+}
+
+type commandEnvKey struct{}
+
+// WithCommandEnv returns a context whose command steps receive the supplied
+// environment variables without modifying the current process environment.
+func WithCommandEnv(ctx context.Context, values map[string]string) context.Context {
+	merged := make(map[string]string)
+	if existing, ok := ctx.Value(commandEnvKey{}).(map[string]string); ok {
+		for key, value := range existing {
+			merged[key] = value
+		}
+	}
+	for key, value := range values {
+		merged[key] = value
+	}
+	return context.WithValue(ctx, commandEnvKey{}, merged)
+}
+
+func commandEnv(ctx context.Context) []string {
+	values, ok := ctx.Value(commandEnvKey{}).(map[string]string)
+	if !ok || len(values) == 0 {
+		return nil
+	}
+
+	keys := make([]string, 0, len(values))
+	for key := range values {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+
+	env := os.Environ()
+	for _, key := range keys {
+		prefix := key + "="
+		for i := 0; i < len(env); {
+			if strings.HasPrefix(env[i], prefix) {
+				env = append(env[:i], env[i+1:]...)
+				continue
+			}
+			i++
+		}
+		env = append(env, prefix+values[key])
+	}
+	return env
 }
 
 func (ds step) run(ctx context.Context, prefix string) bool {
@@ -80,6 +125,9 @@ func Cmd(name string, args ...string) Step {
 	}
 	return F(description, func(ctx context.Context) (string, error) {
 		command := exec.CommandContext(ctx, name, args...)
+		if env := commandEnv(ctx); env != nil {
+			command.Env = env
+		}
 		out, err := command.Output()
 		output = string(out)
 		if exit, ok := err.(*exec.ExitError); ok {

--- a/step/step_test.go
+++ b/step/step_test.go
@@ -1,0 +1,41 @@
+package step
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCommandEnvironment(t *testing.T) {
+	t.Setenv("UPGRADE_PROVIDER_STEP_TEST", "parent")
+
+	var output string
+	ctx := WithCommandEnv(context.Background(), map[string]string{
+		"UPGRADE_PROVIDER_STEP_TEST": "child",
+	})
+	ok := Run(ctx, Cmd("sh", "-c", "printf %s \"$UPGRADE_PROVIDER_STEP_TEST\"").AssignTo(&output))
+
+	require.True(t, ok)
+	assert.Equal(t, "child", output)
+	assert.Equal(t, "parent", os.Getenv("UPGRADE_PROVIDER_STEP_TEST"))
+}
+
+func TestCommandEnvironmentNestedOverride(t *testing.T) {
+	ctx := WithCommandEnv(context.Background(), map[string]string{
+		"UPGRADE_PROVIDER_STEP_FIRST":  "first",
+		"UPGRADE_PROVIDER_STEP_SHARED": "outer",
+	})
+	ctx = WithCommandEnv(ctx, map[string]string{
+		"UPGRADE_PROVIDER_STEP_SECOND": "second",
+		"UPGRADE_PROVIDER_STEP_SHARED": "inner",
+	})
+
+	var output string
+	ok := Run(ctx, Cmd("sh", "-c", `printf "%s|%s|%s" "$UPGRADE_PROVIDER_STEP_FIRST" "$UPGRADE_PROVIDER_STEP_SECOND" "$UPGRADE_PROVIDER_STEP_SHARED"`).AssignTo(&output))
+
+	require.True(t, ok)
+	assert.Equal(t, "first|second|inner", output)
+}

--- a/upgrade/git_identity.go
+++ b/upgrade/git_identity.go
@@ -102,27 +102,35 @@ func (systemGitIdentitySource) GitConfig(ctx context.Context, repoRoot, key stri
 	return "", fmt.Errorf("read effective Git configuration %q in %q: %w", key, repoRoot, err)
 }
 
-// fillMissingIdentity applies one name/email source without replacing fields
-// supplied by a higher-precedence source.
-func fillMissingIdentity(identity *gitIdentity, name, email string) {
-	if identity.AuthorName == "" {
-		identity.AuthorName = name
+// fillMissingPair applies a single name/email source to a pair of fields
+// without replacing values supplied by a higher-precedence source.
+func fillMissingPair(name, email *string, sourceName, sourceEmail string) {
+	if *name == "" {
+		*name = sourceName
 	}
-	if identity.AuthorEmail == "" {
-		identity.AuthorEmail = email
-	}
-	if identity.CommitterName == "" {
-		identity.CommitterName = name
-	}
-	if identity.CommitterEmail == "" {
-		identity.CommitterEmail = email
+	if *email == "" {
+		*email = sourceEmail
 	}
 }
 
+// configPair reads a name/email pair from Git config, trimming whitespace.
+func configPair(ctx context.Context, repoRoot, nameKey, emailKey string, source gitIdentitySource) (name, email string, err error) {
+	name, err = source.GitConfig(ctx, repoRoot, nameKey)
+	if err != nil {
+		return "", "", err
+	}
+	email, err = source.GitConfig(ctx, repoRoot, emailKey)
+	if err != nil {
+		return "", "", err
+	}
+	return strings.TrimSpace(name), strings.TrimSpace(email), nil
+}
+
 // resolveGitIdentity resolves each identity field in precedence order from
-// explicit Git environment and effective provider-repository config. It
-// returns an actionable error unless all four author and committer fields can
-// be resolved.
+// explicit Git environment, then the effective provider-repository
+// author.*/committer.* config (which Git honors when it differs from
+// user.*), then the effective user.* config. It returns an actionable error
+// unless all four author and committer fields can be resolved.
 func resolveGitIdentity(ctx context.Context, repoRoot string, source gitIdentitySource) (gitIdentity, error) {
 	identity := gitIdentity{}
 	explicit := map[string]*string{
@@ -140,15 +148,28 @@ func resolveGitIdentity(ctx context.Context, repoRoot string, source gitIdentity
 		return identity, nil
 	}
 
-	name, err := source.GitConfig(ctx, repoRoot, "user.name")
+	authorName, authorEmail, err := configPair(ctx, repoRoot, "author.name", "author.email", source)
 	if err != nil {
 		return gitIdentity{}, err
 	}
-	email, err := source.GitConfig(ctx, repoRoot, "user.email")
+	fillMissingPair(&identity.AuthorName, &identity.AuthorEmail, authorName, authorEmail)
+
+	committerName, committerEmail, err := configPair(ctx, repoRoot, "committer.name", "committer.email", source)
 	if err != nil {
 		return gitIdentity{}, err
 	}
-	fillMissingIdentity(&identity, strings.TrimSpace(name), strings.TrimSpace(email))
+	fillMissingPair(&identity.CommitterName, &identity.CommitterEmail, committerName, committerEmail)
+
+	if identity.complete() {
+		return identity, nil
+	}
+
+	userName, userEmail, err := configPair(ctx, repoRoot, "user.name", "user.email", source)
+	if err != nil {
+		return gitIdentity{}, err
+	}
+	fillMissingPair(&identity.AuthorName, &identity.AuthorEmail, userName, userEmail)
+	fillMissingPair(&identity.CommitterName, &identity.CommitterEmail, userName, userEmail)
 	if identity.complete() {
 		return identity, nil
 	}

--- a/upgrade/git_identity.go
+++ b/upgrade/git_identity.go
@@ -1,0 +1,193 @@
+package upgrade
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+
+	legacystep "github.com/pulumi/upgrade-provider/step"
+	stepv2 "github.com/pulumi/upgrade-provider/step/v2"
+)
+
+const (
+	gitAuthorName     = "GIT_AUTHOR_NAME"
+	gitAuthorEmail    = "GIT_AUTHOR_EMAIL"
+	gitCommitterName  = "GIT_COMMITTER_NAME"
+	gitCommitterEmail = "GIT_COMMITTER_EMAIL"
+)
+
+// gitIdentityEnvironmentKeys returns the standard Git environment variables
+// required to provide complete author and committer identities.
+func gitIdentityEnvironmentKeys() []string {
+	return []string{
+		gitAuthorName,
+		gitAuthorEmail,
+		gitCommitterName,
+		gitCommitterEmail,
+	}
+}
+
+// gitIdentity is the complete identity exported to child Git processes.
+// Author and committer values are tracked separately so explicit caller values
+// can be preserved while missing fields are filled from later sources.
+type gitIdentity struct {
+	AuthorName     string
+	AuthorEmail    string
+	CommitterName  string
+	CommitterEmail string
+}
+
+// complete reports whether Git can create commits without consulting config.
+func (i gitIdentity) complete() bool {
+	return i.AuthorName != "" && i.AuthorEmail != "" &&
+		i.CommitterName != "" && i.CommitterEmail != ""
+}
+
+// environment converts the identity to Git's standard process environment.
+func (i gitIdentity) environment() map[string]string {
+	return map[string]string{
+		gitAuthorName:     i.AuthorName,
+		gitAuthorEmail:    i.AuthorEmail,
+		gitCommitterName:  i.CommitterName,
+		gitCommitterEmail: i.CommitterEmail,
+	}
+}
+
+// apply scopes the identity to both command implementations used by the
+// upgrade pipeline. Legacy steps receive an explicit exec.Cmd environment;
+// step/v2 enters and restores its existing scoped environment around commands.
+// Git am still takes authorship from each patch and uses this identity only as
+// the committer.
+func (i gitIdentity) apply(ctx context.Context) context.Context {
+	environment := i.environment()
+	ctx = legacystep.WithCommandEnv(ctx, environment)
+	for _, key := range gitIdentityEnvironmentKeys() {
+		ctx = stepv2.WithEnv(ctx, &stepv2.EnvVar{Key: key, Value: environment[key]})
+	}
+	return ctx
+}
+
+// gitIdentitySource isolates environment and Git config lookups so precedence
+// and failure behavior can be tested without changing process state.
+type gitIdentitySource interface {
+	LookupEnv(string) (string, bool)
+	GitConfig(context.Context, string, string) (string, error)
+}
+
+// systemGitIdentitySource reads identity sources from the current process and
+// provider repository.
+type systemGitIdentitySource struct{}
+
+func (systemGitIdentitySource) LookupEnv(key string) (string, bool) {
+	return os.LookupEnv(key)
+}
+
+func (systemGitIdentitySource) GitConfig(ctx context.Context, repoRoot, key string) (string, error) {
+	cmd := exec.CommandContext(ctx, "git", "config", "--get", key)
+	cmd.Dir = repoRoot
+	output, err := cmd.Output()
+	if err == nil {
+		return strings.TrimSpace(string(output)), nil
+	}
+
+	var exitErr *exec.ExitError
+	if errors.As(err, &exitErr) && exitErr.ExitCode() == 1 {
+		return "", nil
+	}
+	return "", fmt.Errorf("read effective Git configuration %q in %q: %w", key, repoRoot, err)
+}
+
+// fillMissingIdentity applies one name/email source without replacing fields
+// supplied by a higher-precedence source.
+func fillMissingIdentity(identity *gitIdentity, name, email string) {
+	if identity.AuthorName == "" {
+		identity.AuthorName = name
+	}
+	if identity.AuthorEmail == "" {
+		identity.AuthorEmail = email
+	}
+	if identity.CommitterName == "" {
+		identity.CommitterName = name
+	}
+	if identity.CommitterEmail == "" {
+		identity.CommitterEmail = email
+	}
+}
+
+// resolveGitIdentity resolves each identity field in precedence order from
+// explicit Git environment and effective provider-repository config. It
+// returns an actionable error unless all four author and committer fields can
+// be resolved.
+func resolveGitIdentity(ctx context.Context, repoRoot string, source gitIdentitySource) (gitIdentity, error) {
+	identity := gitIdentity{}
+	explicit := map[string]*string{
+		gitAuthorName:     &identity.AuthorName,
+		gitAuthorEmail:    &identity.AuthorEmail,
+		gitCommitterName:  &identity.CommitterName,
+		gitCommitterEmail: &identity.CommitterEmail,
+	}
+	for _, key := range gitIdentityEnvironmentKeys() {
+		if value, ok := source.LookupEnv(key); ok && strings.TrimSpace(value) != "" {
+			*explicit[key] = value
+		}
+	}
+	if identity.complete() {
+		return identity, nil
+	}
+
+	name, err := source.GitConfig(ctx, repoRoot, "user.name")
+	if err != nil {
+		return gitIdentity{}, err
+	}
+	email, err := source.GitConfig(ctx, repoRoot, "user.email")
+	if err != nil {
+		return gitIdentity{}, err
+	}
+	fillMissingIdentity(&identity, strings.TrimSpace(name), strings.TrimSpace(email))
+	if identity.complete() {
+		return identity, nil
+	}
+
+	message := fmt.Sprintf(`Git author and committer identity is required to run the patched-provider workflow in %q.
+Supply non-empty %s, %s, %s, and %s environment variables, or configure the provider repository:
+
+  git -C %s config user.name "Your Name"
+  git -C %s config user.email "you@example.com"
+
+Global Git configuration is not required.`, repoRoot,
+		gitAuthorName, gitAuthorEmail, gitCommitterName, gitCommitterEmail,
+		strconv.Quote(filepath.Clean(repoRoot)), strconv.Quote(filepath.Clean(repoRoot)))
+	return gitIdentity{}, errors.New(message)
+}
+
+// resolveGitIdentityStep exposes resolution through the replay-aware step/v2
+// machinery. Identity lookup is impure because it reads environment and Git
+// configuration.
+func resolveGitIdentityStep(ctx context.Context, repoRoot string) gitIdentity {
+	resolve := stepv2.Func11E("Resolve Git Identity", func(
+		ctx context.Context, repoRoot string,
+	) (gitIdentity, error) {
+		stepv2.MarkImpure(ctx)
+		return resolveGitIdentity(ctx, repoRoot, systemGitIdentitySource{})
+	})
+	return resolve(ctx, repoRoot)
+}
+
+// applyGitIdentityPreflight resolves identity and returns a context that passes
+// it to the patched-provider workflow. Callers must invoke this immediately
+// before running scripts/upstream.sh.
+func applyGitIdentityPreflight(ctx context.Context, repoRoot string) (context.Context, error) {
+	var identity gitIdentity
+	err := stepv2.PipelineCtx(ctx, "Git Identity Preflight", func(ctx context.Context) {
+		identity = resolveGitIdentityStep(ctx, repoRoot)
+	})
+	if err != nil {
+		return ctx, err
+	}
+	return identity.apply(ctx), nil
+}

--- a/upgrade/git_identity_test.go
+++ b/upgrade/git_identity_test.go
@@ -49,7 +49,51 @@ func TestResolveGitIdentityFromRepositoryConfig(t *testing.T) {
 		CommitterName:  "Configured User",
 		CommitterEmail: "configured@example.com",
 	}, identity)
-	assert.Equal(t, 2, source.configCalls)
+	assert.Equal(t, 6, source.configCalls)
+}
+
+func TestResolveGitIdentityHonorsAuthorAndCommitterConfigOverUser(t *testing.T) {
+	source := &fakeGitIdentitySource{
+		config: map[string]string{
+			"user.name":       "Fallback User",
+			"user.email":      "fallback@example.com",
+			"author.name":     "Author Config",
+			"author.email":    "author-config@example.com",
+			"committer.name":  "Committer Config",
+			"committer.email": "committer-config@example.com",
+		},
+	}
+
+	identity, err := resolveGitIdentity(context.Background(), "/provider", source)
+
+	require.NoError(t, err)
+	assert.Equal(t, gitIdentity{
+		AuthorName:     "Author Config",
+		AuthorEmail:    "author-config@example.com",
+		CommitterName:  "Committer Config",
+		CommitterEmail: "committer-config@example.com",
+	}, identity)
+}
+
+func TestResolveGitIdentityFillsMissingAuthorOrCommitterFieldsFromUser(t *testing.T) {
+	source := &fakeGitIdentitySource{
+		config: map[string]string{
+			"user.name":    "Fallback User",
+			"user.email":   "fallback@example.com",
+			"author.name":  "Author Config",
+			"author.email": "author-config@example.com",
+		},
+	}
+
+	identity, err := resolveGitIdentity(context.Background(), "/provider", source)
+
+	require.NoError(t, err)
+	assert.Equal(t, gitIdentity{
+		AuthorName:     "Author Config",
+		AuthorEmail:    "author-config@example.com",
+		CommitterName:  "Fallback User",
+		CommitterEmail: "fallback@example.com",
+	}, identity)
 }
 
 func TestResolveGitIdentityExplicitEnvironmentTakesPrecedence(t *testing.T) {

--- a/upgrade/git_identity_test.go
+++ b/upgrade/git_identity_test.go
@@ -1,0 +1,242 @@
+package upgrade
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	legacystep "github.com/pulumi/upgrade-provider/step"
+	stepv2 "github.com/pulumi/upgrade-provider/step/v2"
+)
+
+type fakeGitIdentitySource struct {
+	environment map[string]string
+	config      map[string]string
+
+	configCalls int
+}
+
+func (s *fakeGitIdentitySource) LookupEnv(key string) (string, bool) {
+	value, ok := s.environment[key]
+	return value, ok
+}
+
+func (s *fakeGitIdentitySource) GitConfig(_ context.Context, _, key string) (string, error) {
+	s.configCalls++
+	return s.config[key], nil
+}
+
+func TestResolveGitIdentityFromRepositoryConfig(t *testing.T) {
+	source := &fakeGitIdentitySource{
+		config: map[string]string{
+			"user.name":  "Configured User",
+			"user.email": "configured@example.com",
+		},
+	}
+
+	identity, err := resolveGitIdentity(context.Background(), "/provider", source)
+
+	require.NoError(t, err)
+	assert.Equal(t, gitIdentity{
+		AuthorName:     "Configured User",
+		AuthorEmail:    "configured@example.com",
+		CommitterName:  "Configured User",
+		CommitterEmail: "configured@example.com",
+	}, identity)
+	assert.Equal(t, 2, source.configCalls)
+}
+
+func TestResolveGitIdentityExplicitEnvironmentTakesPrecedence(t *testing.T) {
+	source := &fakeGitIdentitySource{
+		environment: map[string]string{
+			gitAuthorName:     "Explicit Author",
+			gitAuthorEmail:    "author@example.com",
+			gitCommitterName:  "Explicit Committer",
+			gitCommitterEmail: "committer@example.com",
+		},
+		config: map[string]string{"user.name": "Configured", "user.email": "configured@example.com"},
+	}
+
+	identity, err := resolveGitIdentity(context.Background(), "/provider", source)
+
+	require.NoError(t, err)
+	assert.Equal(t, "Explicit Author", identity.AuthorName)
+	assert.Equal(t, "author@example.com", identity.AuthorEmail)
+	assert.Equal(t, "Explicit Committer", identity.CommitterName)
+	assert.Equal(t, "committer@example.com", identity.CommitterEmail)
+	assert.Zero(t, source.configCalls)
+}
+
+func TestResolveGitIdentityFillsPartialEnvironmentByPrecedence(t *testing.T) {
+	source := &fakeGitIdentitySource{
+		environment: map[string]string{
+			gitAuthorName: "Explicit Author",
+		},
+		config: map[string]string{
+			"user.name":  "Configured User",
+			"user.email": "configured@example.com",
+		},
+	}
+
+	identity, err := resolveGitIdentity(context.Background(), "/provider", source)
+
+	require.NoError(t, err)
+	assert.Equal(t, gitIdentity{
+		AuthorName:     "Explicit Author",
+		AuthorEmail:    "configured@example.com",
+		CommitterName:  "Configured User",
+		CommitterEmail: "configured@example.com",
+	}, identity)
+}
+
+func TestResolveGitIdentityFailureIsActionable(t *testing.T) {
+	source := &fakeGitIdentitySource{config: map[string]string{}}
+
+	_, err := resolveGitIdentity(context.Background(), "/provider", source)
+
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "Git author and committer identity is required to run the patched-provider workflow")
+	assert.ErrorContains(t, err, gitAuthorName)
+	assert.ErrorContains(t, err, `git -C "/provider" config user.name`)
+	assert.ErrorContains(t, err, "Global Git configuration is not required")
+}
+
+func TestGitIdentityPreflightFailureIsReadOnly(t *testing.T) {
+	root := t.TempDir()
+	runGitTestCommand(t, root, "init")
+	require.NoError(t, os.WriteFile(filepath.Join(root, "README.md"), []byte("unchanged\n"), 0o600))
+	runGitTestCommand(t, root, "add", "README.md")
+	runGitTestCommand(t, root, "-c", "user.name=Initial Author", "-c", "user.email=initial@example.com", "commit", "-m", "initial")
+
+	for _, key := range gitIdentityEnvironmentKeys() {
+		t.Setenv(key, "")
+	}
+	t.Setenv("GIT_CONFIG_GLOBAL", os.DevNull)
+	t.Setenv("GIT_CONFIG_NOSYSTEM", "1")
+	t.Setenv("HOME", t.TempDir())
+
+	before := runGitTestCommand(t, root, "status", "--porcelain=v1", "--branch")
+	_, err := applyGitIdentityPreflight(context.Background(), root)
+	require.Error(t, err)
+	after := runGitTestCommand(t, root, "status", "--porcelain=v1", "--branch")
+	assert.Equal(t, before, after)
+}
+
+func TestGitIdentityV2EnvironmentIsScoped(t *testing.T) {
+	for _, key := range gitIdentityEnvironmentKeys() {
+		t.Setenv(key, "original-"+key)
+	}
+	identity := gitIdentity{
+		AuthorName:     "Author",
+		AuthorEmail:    "author@example.com",
+		CommitterName:  "Committer",
+		CommitterEmail: "committer@example.com",
+	}
+
+	var output string
+	err := stepv2.PipelineCtx(identity.apply(context.Background()), "identity", func(ctx context.Context) {
+		output = stepv2.Cmd(ctx, "sh", "-c", `printf "%s|%s|%s|%s" "$GIT_AUTHOR_NAME" "$GIT_AUTHOR_EMAIL" "$GIT_COMMITTER_NAME" "$GIT_COMMITTER_EMAIL"`)
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "Author|author@example.com|Committer|committer@example.com", output)
+
+	for _, key := range gitIdentityEnvironmentKeys() {
+		assert.Equal(t, "original-"+key, os.Getenv(key))
+	}
+}
+
+func TestGitIdentityPreservesGitAmAuthor(t *testing.T) {
+	sourceRepo := filepath.Join(t.TempDir(), "source")
+	runGitTestCommand(t, sourceRepo, "init")
+	require.NoError(t, os.WriteFile(filepath.Join(sourceRepo, "README.md"), []byte("base\n"), 0o600))
+	runGitTestCommand(t, sourceRepo, "add", "README.md")
+	runGitTestCommand(t, sourceRepo, "-c", "user.name=Base Author", "-c", "user.email=base@example.com", "commit", "-m", "base")
+	require.NoError(t, os.WriteFile(filepath.Join(sourceRepo, "README.md"), []byte("patched\n"), 0o600))
+	runGitTestCommand(t, sourceRepo, "add", "README.md")
+	runGitTestCommand(t, sourceRepo, "-c", "user.name=Patch Author", "-c", "user.email=patch@example.com", "commit", "-m", "patch")
+	patch := runGitTestCommand(t, sourceRepo, "format-patch", "-1", "--stdout", "HEAD")
+
+	targetRepo := filepath.Join(t.TempDir(), "target")
+	runGitTestCommand(t, targetRepo, "init")
+	require.NoError(t, os.WriteFile(filepath.Join(targetRepo, "README.md"), []byte("base\n"), 0o600))
+	runGitTestCommand(t, targetRepo, "add", "README.md")
+	runGitTestCommand(t, targetRepo, "-c", "user.name=Base Author", "-c", "user.email=base@example.com", "commit", "-m", "base")
+	patchPath := filepath.Join(targetRepo, "patch.patch")
+	require.NoError(t, os.WriteFile(patchPath, []byte(patch), 0o600))
+
+	identity := gitIdentity{
+		AuthorName:     "Resolved User",
+		AuthorEmail:    "resolved@example.com",
+		CommitterName:  "Resolved User",
+		CommitterEmail: "resolved@example.com",
+	}
+	ok := legacystep.Run(identity.apply(context.Background()),
+		legacystep.Cmd("git", "am", patchPath).In(&targetRepo))
+	require.True(t, ok)
+
+	output := runGitTestCommand(t, targetRepo, "show", "-s", "--format=%an|%ae|%cn|%ce", "HEAD")
+	assert.Equal(t, "Patch Author|patch@example.com|Resolved User|resolved@example.com", strings.TrimSpace(output))
+}
+
+func TestRepositoryIdentityPropagatesThroughUpstreamScript(t *testing.T) {
+	t.Setenv("GIT_CONFIG_GLOBAL", os.DevNull)
+	t.Setenv("GIT_CONFIG_NOSYSTEM", "1")
+	t.Setenv("HOME", t.TempDir())
+
+	root := t.TempDir()
+	sourceRepo := filepath.Join(t.TempDir(), "source")
+	runGitTestCommand(t, sourceRepo, "init")
+	require.NoError(t, os.WriteFile(filepath.Join(sourceRepo, "README.md"), []byte("source\n"), 0o600))
+	runGitTestCommand(t, sourceRepo, "add", "README.md")
+	runGitTestCommand(t, sourceRepo, "-c", "user.name=Source Author", "-c", "user.email=source@example.com", "commit", "-m", "initial")
+
+	runGitTestCommand(t, root, "init")
+	runGitTestCommand(t, root, "config", "user.name", "Repository User")
+	runGitTestCommand(t, root, "config", "user.email", "repository@example.com")
+	require.NoError(t, os.WriteFile(filepath.Join(root, "README.md"), []byte("root\n"), 0o600))
+	runGitTestCommand(t, root, "add", "README.md")
+	runGitTestCommand(t, root, "commit", "-m", "initial")
+	runGitTestCommand(t, root, "-c", "protocol.file.allow=always", "submodule", "add", sourceRepo, "upstream")
+
+	for _, key := range gitIdentityEnvironmentKeys() {
+		t.Setenv(key, "")
+	}
+
+	scriptDir := filepath.Join(root, "scripts")
+	require.NoError(t, os.Mkdir(scriptDir, 0o700))
+	scriptPath := filepath.Join(scriptDir, "upstream.sh")
+	require.NoError(t, os.WriteFile(scriptPath, []byte("#!/bin/sh\nset -eu\ncd upstream\ngit commit --allow-empty -m identity-test\n"), 0o700))
+
+	identity, err := resolveGitIdentity(context.Background(), root, systemGitIdentitySource{})
+	require.NoError(t, err)
+
+	ctx := identity.apply(context.Background())
+	ok := legacystep.Run(ctx, legacystep.Cmd("./scripts/upstream.sh").In(&root))
+	require.True(t, ok)
+
+	output := runGitTestCommand(t, filepath.Join(root, "upstream"), "show", "-s", "--format=%an|%ae|%cn|%ce", "HEAD")
+	assert.Equal(t, "Repository User|repository@example.com|Repository User|repository@example.com", strings.TrimSpace(output))
+	for _, key := range gitIdentityEnvironmentKeys() {
+		value, ok := os.LookupEnv(key)
+		assert.True(t, ok)
+		assert.Empty(t, value)
+	}
+}
+
+func runGitTestCommand(t *testing.T, dir string, args ...string) string {
+	t.Helper()
+	if args[0] == "init" {
+		require.NoError(t, os.MkdirAll(dir, 0o700))
+	}
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	output, err := cmd.CombinedOutput()
+	require.NoErrorf(t, err, "git %s failed:\n%s", strings.Join(args, " "), output)
+	return string(output)
+}

--- a/upgrade/upgrade_provider.go
+++ b/upgrade/upgrade_provider.go
@@ -271,6 +271,16 @@ func UpgradeProvider(ctx context.Context, repoOrg, repoName string) (err error) 
 		steps = append(steps, applyPulumiVersion(ctx, repo))
 	}
 
+	// Patched-provider upgrades run scripts/upstream.sh, whose checkout command
+	// creates commits inside the upstream submodule. Resolve identity immediately
+	// before entering that flow so git am and the later Git commands can commit.
+	if GetContext(ctx).UpgradeProviderVersion && goMod.Kind.IsPatched() {
+		ctx, err = applyGitIdentityPreflight(ctx, repo.root)
+		if err != nil {
+			return err
+		}
+	}
+
 	ok := step.Run(ctx, step.Combined("Update Repository", steps...))
 	if !ok {
 		return ErrHandled


### PR DESCRIPTION
## Summary

- resolve Git author and committer identity from explicit `GIT_AUTHOR_*` / `GIT_COMMITTER_*` values, then effective provider-repository config
- propagate the resolved identity to `scripts/upstream.sh`, Git commands inside the upstream submodule, and subsequent upgrade commands without writing global config
- fail with repository-local configuration instructions when identity remains incomplete
- document and test the patched-provider behavior, including preservation of patch authors during `git am`

## Why

Repository-local `user.name` and `user.email` in the provider root do not apply inside the `upstream` submodule. In sandboxed environments without global Git config, `scripts/upstream.sh checkout` therefore fails when `git am` attempts to create commits.

The preflight is intentionally limited to patched provider-version upgrades immediately before entering the upstream patch workflow. It does not depend on `gh api user` or broader checkout timing changes.

## Testing

- `go test -count=1 ./...`
- `go vet ./...`
- `golangci-lint run --new-from-rev=HEAD`
- `go test -race ./step/... ./upgrade/...`
