### PR TITLE
Make patched-provider recovery fail safely

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,6 +179,39 @@ To fix an error:
 
 Repeat as necessary for a working upgrade.
 
+#### Recovering patched-provider upgrades
+
+Patched providers use `./scripts/upstream.sh` to check patches out as commits,
+rebase them onto the requested upstream version, and write them back to
+`patches/`. If this workflow is interrupted, `upgrade-provider` stops without
+trying to infer or modify the partial Git state.
+
+To preserve the work:
+
+1. Complete any active `git am` or rebase inside `upstream`.
+2. Ensure every patch has been applied and the target rebase has completed.
+3. From the provider repository, run:
+
+   ```sh
+   ./scripts/upstream.sh check_in
+   ```
+
+4. Rerun `upgrade-provider`.
+
+A checkout applies each `patches/*.patch` file with a separate `git am`. After
+`git am --continue`, apply any later patch files that the interrupted checkout
+had not reached before starting the target rebase. Do not run `check_in` on a
+partial patch stack.
+
+To intentionally discard the interrupted work, run:
+
+```sh
+./scripts/upstream.sh init -f
+```
+
+This is **destructive** and can discard conflict resolution and patch commits.
+It is an explicit discard option, not a normal preflight or recovery step.
+
 ### In a GitHub Action (experimental)
 
 1. Ensure you have an [`upgrade-config.yml`](#Configuration) set in the root of your provider:

--- a/upgrade/patched_provider.go
+++ b/upgrade/patched_provider.go
@@ -29,6 +29,10 @@ func patchedProviderUpgradeStep(repo ProviderRepo, targetRef string) step.Step {
 
 func patchedProviderUpgradeCommands(targetRef string) [][]string {
 	return [][]string{
+		// Initialize before fetching so a fresh clone can resolve the target.
+		{"git", "submodule", "update", "--force", "--init", "--", "upstream"},
+		// Preserve an explicit tag fetch because rebase names the target tag directly.
+		{"git", "-C", "upstream", "fetch", "--tags"},
 		{"./scripts/upstream.sh", "checkout"},
 		{"./scripts/upstream.sh", "rebase", "-o", targetRef},
 		{"./scripts/upstream.sh", "check_in"},

--- a/upgrade/patched_provider.go
+++ b/upgrade/patched_provider.go
@@ -1,0 +1,148 @@
+package upgrade
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	"github.com/pulumi/upgrade-provider/step"
+)
+
+const patchCheckoutBranch = "pulumi/patch-checkout"
+
+func patchedProviderUpgradeStep(repo ProviderRepo, targetRef string) step.Step {
+	upstreamDir := filepath.Join(repo.root, "upstream")
+	steps := []step.Step{
+		step.F("Check patched provider state", func(ctx context.Context) (string, error) {
+			return checkPatchedProviderPreflight(ctx, upstreamDir, targetRef)
+		}),
+	}
+	for _, command := range patchedProviderUpgradeCommands(targetRef) {
+		steps = append(steps, step.Cmd(command[0], command[1:]...).In(&repo.root))
+	}
+	return step.Combined("update patched provider", steps...)
+}
+
+func patchedProviderUpgradeCommands(targetRef string) [][]string {
+	return [][]string{
+		{"./scripts/upstream.sh", "checkout"},
+		{"./scripts/upstream.sh", "rebase", "-o", targetRef},
+		{"./scripts/upstream.sh", "check_in"},
+	}
+}
+
+// checkPatchedProviderPreflight refuses to interpret or modify interrupted
+// patch workflows. Recovery is deliberately manual because Git cannot prove
+// that every patch was applied before an interruption.
+func checkPatchedProviderPreflight(
+	ctx context.Context, upstreamDir, targetRef string,
+) (string, error) {
+	initialized, err := patchedProviderInitialized(upstreamDir)
+	if err != nil {
+		return "", err
+	}
+	if !initialized {
+		return "upstream submodule not yet initialized", nil
+	}
+
+	operationActive, err := hasActivePatchedGitOperation(ctx, upstreamDir)
+	if err != nil {
+		return "", err
+	}
+	if operationActive {
+		return "", fmt.Errorf(`the patched upstream repository has an active Git operation
+
+upgrade-provider left it unchanged. Complete or abort the operation manually.
+To preserve a completed patch upgrade, ensure every patch is applied and the target rebase is complete, then run:
+  ./scripts/upstream.sh check_in
+
+Rerun upgrade-provider after check_in succeeds.
+To intentionally discard the interrupted work, run ./scripts/upstream.sh init -f.
+That command is destructive and can discard conflict resolution and patch commits`)
+	}
+
+	branch, err := patchedGitOutput(ctx, upstreamDir, "branch", "--show-current")
+	if err != nil {
+		return "", fmt.Errorf("inspect patched upstream branch: %w", err)
+	}
+	branch = strings.TrimSpace(branch)
+	if branch == patchCheckoutBranch {
+		return "", fmt.Errorf(`the patched upstream repository is still checked out on %s
+
+upgrade-provider left it unchanged because it cannot prove whether checkout or rebase completed.
+To preserve the work:
+  1. Ensure every patch has been applied.
+  2. If needed, run ./scripts/upstream.sh rebase -o %s and complete the rebase.
+  3. Run ./scripts/upstream.sh check_in.
+  4. Rerun upgrade-provider.
+
+To intentionally discard the interrupted work, run ./scripts/upstream.sh init -f.
+That command is destructive and can discard conflict resolution and patch commits`, patchCheckoutBranch, targetRef)
+	}
+	if branch != "" {
+		return "", fmt.Errorf(`the patched upstream repository is checked out on unexpected branch %q
+
+upgrade-provider left it unchanged. Inspect the branch and return upstream to its expected detached state before rerunning`, branch)
+	}
+
+	return "ready", nil
+}
+
+func patchedProviderInitialized(upstreamDir string) (bool, error) {
+	entries, err := os.ReadDir(upstreamDir)
+	if errors.Is(err, os.ErrNotExist) {
+		return false, nil
+	}
+	if err != nil {
+		return false, fmt.Errorf("read upstream directory: %w", err)
+	}
+
+	if _, err := os.Stat(filepath.Join(upstreamDir, ".git")); err == nil {
+		return true, nil
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return false, fmt.Errorf("inspect upstream Git metadata: %w", err)
+	}
+	if len(entries) == 0 {
+		return false, nil
+	}
+	return false, fmt.Errorf("upstream is not an initialized Git repository but contains files")
+}
+
+func hasActivePatchedGitOperation(ctx context.Context, upstreamDir string) (bool, error) {
+	gitDir, err := patchedGitOutput(ctx, upstreamDir, "rev-parse", "--absolute-git-dir")
+	if err != nil {
+		return false, fmt.Errorf("resolve upstream Git directory: %w", err)
+	}
+
+	for _, name := range []string{
+		"rebase-merge",
+		"rebase-apply",
+		"MERGE_HEAD",
+		"CHERRY_PICK_HEAD",
+		"REVERT_HEAD",
+		"sequencer",
+		"BISECT_START",
+	} {
+		if _, err := os.Stat(filepath.Join(strings.TrimSpace(gitDir), name)); err == nil {
+			return true, nil
+		} else if !errors.Is(err, os.ErrNotExist) {
+			return false, fmt.Errorf("inspect Git operation path %q: %w", name, err)
+		}
+	}
+	return false, nil
+}
+
+func patchedGitOutput(ctx context.Context, dir string, args ...string) (string, error) {
+	cmd := exec.CommandContext(ctx, "git", args...)
+	cmd.Dir = dir
+	cmd.Env = append(os.Environ(), "GIT_OPTIONAL_LOCKS=0")
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return "", fmt.Errorf("git %s: %w: %s", strings.Join(args, " "), err, strings.TrimSpace(string(output)))
+	}
+	return string(output), nil
+}

--- a/upgrade/patched_provider_test.go
+++ b/upgrade/patched_provider_test.go
@@ -16,6 +16,8 @@ func TestPatchedProviderUpgradeCommands(t *testing.T) {
 	t.Parallel()
 
 	assert.Equal(t, [][]string{
+		{"git", "submodule", "update", "--force", "--init", "--", "upstream"},
+		{"git", "-C", "upstream", "fetch", "--tags"},
 		{"./scripts/upstream.sh", "checkout"},
 		{"./scripts/upstream.sh", "rebase", "-o", "refs/tags/v1.2.3"},
 		{"./scripts/upstream.sh", "check_in"},

--- a/upgrade/patched_provider_test.go
+++ b/upgrade/patched_provider_test.go
@@ -1,0 +1,130 @@
+package upgrade
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPatchedProviderUpgradeCommands(t *testing.T) {
+	t.Parallel()
+
+	assert.Equal(t, [][]string{
+		{"./scripts/upstream.sh", "checkout"},
+		{"./scripts/upstream.sh", "rebase", "-o", "refs/tags/v1.2.3"},
+		{"./scripts/upstream.sh", "check_in"},
+	}, patchedProviderUpgradeCommands("refs/tags/v1.2.3"))
+}
+
+func TestCheckPatchedProviderPreflight(t *testing.T) {
+	t.Parallel()
+
+	t.Run("uninitialized submodule", func(t *testing.T) {
+		t.Parallel()
+		upstream := t.TempDir()
+
+		result, err := checkPatchedProviderPreflight(
+			context.Background(), upstream, "refs/tags/v1.2.3")
+
+		require.NoError(t, err)
+		assert.Contains(t, result, "not yet initialized")
+	})
+
+	t.Run("normal detached state", func(t *testing.T) {
+		t.Parallel()
+		upstream := newPatchedTestRepo(t)
+		runPatchedTestGit(t, upstream, "checkout", "--detach")
+
+		result, err := checkPatchedProviderPreflight(
+			context.Background(), upstream, "refs/tags/v1.2.3")
+
+		require.NoError(t, err)
+		assert.Equal(t, "ready", result)
+	})
+
+	t.Run("patch checkout requires manual recovery", func(t *testing.T) {
+		t.Parallel()
+		upstream := newPatchedTestRepo(t)
+		runPatchedTestGit(t, upstream, "checkout", "-b", patchCheckoutBranch)
+		before := runPatchedTestGit(t, upstream, "rev-parse", "HEAD")
+
+		_, err := checkPatchedProviderPreflight(
+			context.Background(), upstream, "refs/tags/v1.2.3")
+
+		require.ErrorContains(t, err, patchCheckoutBranch)
+		require.ErrorContains(t, err, "./scripts/upstream.sh rebase -o refs/tags/v1.2.3")
+		require.ErrorContains(t, err, "./scripts/upstream.sh check_in")
+		require.ErrorContains(t, err, "destructive")
+		assert.Equal(t, patchCheckoutBranch,
+			strings.TrimSpace(runPatchedTestGit(t, upstream, "branch", "--show-current")))
+		assert.Equal(t, before, runPatchedTestGit(t, upstream, "rev-parse", "HEAD"))
+	})
+
+	t.Run("active operation stops before branch recovery", func(t *testing.T) {
+		t.Parallel()
+		upstream := newPatchedTestRepo(t)
+		runPatchedTestGit(t, upstream, "checkout", "-b", patchCheckoutBranch)
+		gitDir := strings.TrimSpace(runPatchedTestGit(t, upstream, "rev-parse", "--absolute-git-dir"))
+		require.NoError(t, os.Mkdir(filepath.Join(gitDir, "rebase-merge"), 0o700))
+
+		_, err := checkPatchedProviderPreflight(
+			context.Background(), upstream, "refs/tags/v1.2.3")
+
+		require.ErrorContains(t, err, "active Git operation")
+		require.ErrorContains(t, err, "upgrade-provider left it unchanged")
+		require.ErrorContains(t, err, "./scripts/upstream.sh check_in")
+	})
+
+	t.Run("unexpected branch is preserved", func(t *testing.T) {
+		t.Parallel()
+		upstream := newPatchedTestRepo(t)
+		runPatchedTestGit(t, upstream, "checkout", "-b", "feature")
+
+		_, err := checkPatchedProviderPreflight(
+			context.Background(), upstream, "refs/tags/v1.2.3")
+
+		require.ErrorContains(t, err, `unexpected branch "feature"`)
+		assert.Equal(t, "feature", strings.TrimSpace(runPatchedTestGit(t, upstream, "branch", "--show-current")))
+	})
+
+	t.Run("non-repository contents are preserved", func(t *testing.T) {
+		t.Parallel()
+		upstream := t.TempDir()
+		require.NoError(t, os.WriteFile(filepath.Join(upstream, "work.txt"), []byte("keep"), 0o600))
+
+		_, err := checkPatchedProviderPreflight(
+			context.Background(), upstream, "refs/tags/v1.2.3")
+
+		require.ErrorContains(t, err, "not an initialized Git repository but contains files")
+		content, readErr := os.ReadFile(filepath.Join(upstream, "work.txt"))
+		require.NoError(t, readErr)
+		assert.Equal(t, "keep", string(content))
+	})
+}
+
+func newPatchedTestRepo(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	runPatchedTestGit(t, dir, "init")
+	runPatchedTestGit(t, dir, "config", "user.name", "Upgrade Provider Test")
+	runPatchedTestGit(t, dir, "config", "user.email", "upgrade-provider@example.com")
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "provider.txt"), []byte("upstream\n"), 0o600))
+	runPatchedTestGit(t, dir, "add", "provider.txt")
+	runPatchedTestGit(t, dir, "commit", "-m", "initial")
+	return dir
+}
+
+func runPatchedTestGit(t *testing.T, dir string, args ...string) string {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	output, err := cmd.CombinedOutput()
+	require.NoError(t, err, "git %s failed: %s", strings.Join(args, " "), output)
+	return string(output)
+}

--- a/upgrade/steps.go
+++ b/upgrade/steps.go
@@ -89,85 +89,10 @@ func UpgradeProviderVersion(
 ) step.Step {
 	steps := []step.Step{}
 	if goMod.Kind.IsPatched() {
-		// If the provider is patched, we don't use the go module system at all. Instead
-		// we update the module referenced to the new tag.
-		upstreamDir := filepath.Join(repo.root, "upstream")
-
-		// Check if we're in a rebase state (user fixed rebase manually)
-		// This handles the case where `upgrade-provider` fails due to patch conflicts.
-		// In that case the user has to fix them and run `git rebase --continue` themselves.
-		var rebaseInProgress bool
-		var rebaseMergePath string
-		var rebaseApplyPath string
-		var currentBranch string
-		checkRebaseState := step.Combined("Check rebase state",
-			// these two checks are based on the check we have in `scripts/upstream.sh` to check if a rebase is in progress
-			step.Cmd("git", "rev-parse", "--git-path", "rebase-merge").In(&upstreamDir).AssignTo(&rebaseMergePath),
-			step.Cmd("git", "rev-parse", "--git-path", "rebase-apply").In(&upstreamDir).AssignTo(&rebaseApplyPath),
-			// If the user has completed the rebase (i.e. `git rebase --continue`) then we will not be in a rebase
-			// but we can't just start the tool over again because it will reset the submodule. At this point all that's
-			// left is `check_in`. After check_in is run we won't be in a branch.
-			step.Cmd("git", "branch", "--show-current").In(&upstreamDir).AssignTo(&currentBranch),
-			step.F("Check rebase state", func(ctx context.Context) (string, error) {
-				// First check if the upstream submodule has been initialized
-				gitModulesDir := filepath.Join(repo.root, ".git", "modules", "upstream")
-				if _, err := os.Stat(gitModulesDir); err != nil {
-					rebaseInProgress = false
-					return "upstream submodule not yet initialized", nil
-				}
-				// First check if we have a current branch - if not, we're not in a rebase
-				currentBranchTrimmed := strings.TrimSpace(currentBranch)
-				if currentBranchTrimmed == "" {
-					rebaseInProgress = false
-					return "no current branch - not in rebase", nil
-				}
-
-				// Convert relative paths to absolute paths from upstream directory
-				rebaseMergeDir := filepath.Join(upstreamDir, strings.TrimSpace(rebaseMergePath))
-				rebaseApplyDir := filepath.Join(upstreamDir, strings.TrimSpace(rebaseApplyPath))
-
-				if _, err := os.Stat(rebaseMergeDir); err == nil {
-					rebaseInProgress = true
-					return "rebase-merge directory found", nil
-				}
-				if _, err := os.Stat(rebaseApplyDir); err == nil {
-					rebaseInProgress = true
-					return "rebase-apply directory found", nil
-				}
-
-				// We have a branch but no rebase directories - likely completed rebase needing check_in
-				rebaseInProgress = true
-				return fmt.Sprintf("branch '%s' exists in '%s' - rebase completed, needs check_in", currentBranchTrimmed, upstreamDir), nil
-			}),
-		)
-
-		// Steps to run when no rebase is in progress (normal flow)
-		normalSteps := step.Combined("update patched provider",
-			step.Cmd("git", "submodule", "update", "--force", "--init").In(&upstreamDir),
-			step.Cmd("git", "fetch", "--tags").In(&upstreamDir),
-			// We need to remove any patches to so we can cleanly pull the next upstream version.
-			step.Cmd("git", "reset", "HEAD", "--hard").In(&upstreamDir),
-			// Load patches into a branch.
-			step.Cmd("./scripts/upstream.sh", "checkout").In(&repo.root),
-			// Rebase the upstream tracking branch onto the new version.
-			step.Cmd("./scripts/upstream.sh", "rebase", "-o", "refs/tags/v"+target.String()).In(&repo.root),
-			// Turn the rebased commits back into patches.
-			step.Cmd("./scripts/upstream.sh", "check_in").In(&repo.root),
-		)
-
-		// Step to run when rebase is in progress (only check_in)
-		checkInOnly := step.Cmd("./scripts/upstream.sh", "check_in").In(&repo.root)
-
-		steps = append(steps,
-			checkRebaseState,
-			step.Computed(func() step.Step {
-				if rebaseInProgress {
-					return step.Combined("complete rebase (check_in only)", checkInOnly)
-				} else {
-					return normalSteps
-				}
-			}),
-		)
+		// Patched providers use a submodule and a local patch stack. Refuse to
+		// modify interrupted workflows; recovery is deliberately manual.
+		targetRef := "refs/tags/v" + target.String()
+		steps = append(steps, patchedProviderUpgradeStep(repo, targetRef))
 	}
 
 	// We have an upstream we don't control, so we need to get it's SHA. We do this


### PR DESCRIPTION
## Summary

- replace patched-provider resume inference with a read-only preflight
- stop with actionable manual recovery instructions when Git state is interrupted or unexpected
- initialize the upstream submodule and fetch target tags only after preflight succeeds
- delegate the normal checkout, target rebase, and check-in sequence to `scripts/upstream.sh`
- document preservation versus destructive discard recovery and add focused tests

## Rationale

Git cannot prove that every patch was applied when `upstream.sh checkout` is interrupted between its separate `git am` invocations. Automatically interpreting a checkout branch as a completed rebase can therefore check in a partial patch stack. The existing logic can also misclassify an active rebase with detached `HEAD` and run destructive setup commands before `upstream.sh` has a chance to reject it.

This change deliberately makes interrupted recovery manual. After completing all patch application and the target rebase, users run `./scripts/upstream.sh check_in` and rerun `upgrade-provider`. `init -f` remains available only as an explicitly destructive discard option.

This intentionally removes the automatic `check_in` recovery behavior introduced by #357 in favor of a safe, noisy failure.

## Testing

- `go test ./...`
- `go test -race ./upgrade`
- `go vet ./...`
- `golangci-lint run --new-from-rev=origin/main`
- `git diff origin/main...HEAD --check`
